### PR TITLE
Add mapping graph kernel interface and mock

### DIFF
--- a/GaymController/interfaces/MappingGraphKernel.cs
+++ b/GaymController/interfaces/MappingGraphKernel.cs
@@ -1,0 +1,19 @@
+using GaymController.Shared.Mapping;
+
+namespace GaymController.Interfaces.Mapping {
+    /// <summary>
+    /// Describes the minimal kernel-side mapping graph engine. Nodes are
+    /// addressed by string identifiers and receive input events and tick updates.
+    /// The implementation should avoid per-event allocations on hot paths.
+    /// </summary>
+    public interface IMappingGraphKernel {
+        /// <summary>Register a node with the graph.</summary>
+        void AddNode(INode node);
+        /// <summary>Connect one node's output to another's input.</summary>
+        void Connect(string srcId, string dstId);
+        /// <summary>Dispatch an input event into a node.</summary>
+        void Dispatch(string nodeId, InputEvent e);
+        /// <summary>Tick all nodes in the graph.</summary>
+        void Tick(double dtMs);
+    }
+}

--- a/GaymController/mocks/MappingGraphKernel.Tests/MappingGraphKernel.Tests.csproj
+++ b/GaymController/mocks/MappingGraphKernel.Tests/MappingGraphKernel.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\MappingGraphKernel\\MappingGraphKernel.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+</Project>

--- a/GaymController/mocks/MappingGraphKernel.Tests/MappingGraphKernelTests.cs
+++ b/GaymController/mocks/MappingGraphKernel.Tests/MappingGraphKernelTests.cs
@@ -1,0 +1,37 @@
+using GaymController.Mocks.Mapping;
+using GaymController.Shared.Mapping;
+using Xunit;
+
+class DummyNode : INode {
+    public string Id { get; }
+    public int EventCount;
+    public double LastValue;
+    public double TickSum;
+    public DummyNode(string id){ Id=id; }
+    public void OnEvent(InputEvent e){ EventCount++; LastValue=e.Value; }
+    public void OnTick(double dtMs){ TickSum+=dtMs; }
+}
+
+public class MappingGraphKernelTests {
+    [Fact]
+    public void DispatchHitsConnectedNodes() {
+        var kernel = new MappingGraphKernel();
+        var a = new DummyNode("A");
+        var b = new DummyNode("B");
+        kernel.AddNode(a); kernel.AddNode(b); kernel.Connect("A","B");
+        kernel.Dispatch("A", new InputEvent("src", 1.0, 0));
+        Assert.Equal(1, a.EventCount);
+        Assert.Equal(1, b.EventCount);
+    }
+
+    [Fact]
+    public void TickPropagatesToAllNodes(){
+        var kernel = new MappingGraphKernel();
+        var a = new DummyNode("A");
+        var b = new DummyNode("B");
+        kernel.AddNode(a); kernel.AddNode(b);
+        kernel.Tick(5.0);
+        Assert.Equal(5.0, a.TickSum);
+        Assert.Equal(5.0, b.TickSum);
+    }
+}

--- a/GaymController/mocks/MappingGraphKernel/MappingGraphKernel.cs
+++ b/GaymController/mocks/MappingGraphKernel/MappingGraphKernel.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using GaymController.Shared.Mapping;
+using GaymController.Interfaces.Mapping;
+
+namespace GaymController.Mocks.Mapping {
+    /// <summary>
+    /// Simple in-memory mapping graph kernel used for testing. Hot paths avoid
+    /// allocations by reusing collections.
+    /// </summary>
+    public sealed class MappingGraphKernel : IMappingGraphKernel {
+        private readonly Dictionary<string, INode> _nodes = new();
+        private readonly Dictionary<string, List<INode>> _edges = new();
+
+        public void AddNode(INode node) {
+            _nodes[node.Id] = node;
+        }
+
+        public void Connect(string srcId, string dstId) {
+            if (!_nodes.ContainsKey(srcId) || !_nodes.ContainsKey(dstId)) return;
+            if (!_edges.TryGetValue(srcId, out var list)) {
+                list = new List<INode>();
+                _edges[srcId] = list;
+            }
+            if (!list.Contains(_nodes[dstId])) {
+                list.Add(_nodes[dstId]);
+            }
+        }
+
+        public void Dispatch(string nodeId, InputEvent e) {
+            if (!_nodes.TryGetValue(nodeId, out var node)) return;
+            node.OnEvent(e);
+            if (_edges.TryGetValue(nodeId, out var list)) {
+                foreach (var n in list) n.OnEvent(e);
+            }
+        }
+
+        public void Tick(double dtMs) {
+            foreach (var n in _nodes.Values) n.OnTick(dtMs);
+        }
+    }
+}

--- a/GaymController/mocks/MappingGraphKernel/MappingGraphKernel.csproj
+++ b/GaymController/mocks/MappingGraphKernel/MappingGraphKernel.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\\..\\interfaces\\MappingGraphKernel.cs" Link="IMappingGraphKernel.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\shared\\Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/GaymController/reports/GC-PAR-004.json
+++ b/GaymController/reports/GC-PAR-004.json
@@ -1,0 +1,25 @@
+{
+  "task_id": "GC-PAR-004",
+  "title": "Mapping Graph Kernel Skeleton",
+  "version": "0.1",
+  "component": "parallel",
+  "reference": {
+    "consulted": true,
+    "files": ["reference/PERFECT/Mapping/InputRouter.cs"],
+    "notes": "Reviewed routing behaviour."
+  },
+  "files": [
+    {"path": "interfaces/MappingGraphKernel.cs", "sha256": "730576e18bfa877b044affd221eea41640d3f224b60d1845e18d26086e1a6d36"},
+    {"path": "mocks/MappingGraphKernel/MappingGraphKernel.cs", "sha256": "3ac67243d446904de2bebf1017b1a43b33c5e08a4f14bffced897513b5111622"},
+    {"path": "mocks/MappingGraphKernel/MappingGraphKernel.csproj", "sha256": "1b0e505e3cc6ab5e021ecbb3c470a1169528cdc2a6e2dd63b6ff3f859ec0d0d7"},
+    {"path": "mocks/MappingGraphKernel.Tests/MappingGraphKernel.Tests.csproj", "sha256": "9272ab274b37018ee2496d78568f8682723d840c8e6cfd11ccdb47624c9b22db"},
+    {"path": "mocks/MappingGraphKernel.Tests/MappingGraphKernelTests.cs", "sha256": "ff25df68625dd701d0c26141c9c2a3137114ab29b2581310e75e95f7555931dd"},
+    {"path": "tasks/parallel/GC-PAR-004.md", "sha256": "4fc833a44c80111a83a785a3c7f2b337e4407c2d9c29e0c180a5d3a462d83fe6"}
+  ],
+  "wiring": {
+    "how_to_hook": "Use MappingGraphKernel mock for testing; swap with real kernel driver implementation when available."
+  },
+  "results": {
+    "notes": "dotnet test mocks/MappingGraphKernel.Tests succeeded"
+  }
+}

--- a/GaymController/reports/GC-PAR-004.md
+++ b/GaymController/reports/GC-PAR-004.md
@@ -1,0 +1,27 @@
+# GC-PAR-004 — Mapping Graph Kernel Skeleton
+
+## Summary
+Added a minimal kernel-style mapping graph interface and a mock in-memory
+implementation for testing.
+
+## Interfaces/Contracts
+- interfaces/MappingGraphKernel.cs — defines `IMappingGraphKernel` for adding
+  nodes, connecting them, dispatching events, and ticking.
+
+## Files Changed
+- interfaces/MappingGraphKernel.cs: new interface definition.
+- mocks/MappingGraphKernel/MappingGraphKernel.csproj: mock library project.
+- mocks/MappingGraphKernel/MappingGraphKernel.cs: mock implementation.
+- mocks/MappingGraphKernel.Tests/MappingGraphKernel.Tests.csproj: xUnit test project.
+- mocks/MappingGraphKernel.Tests/MappingGraphKernelTests.cs: basic dispatch/tick tests.
+- tasks/parallel/GC-PAR-004.md: noted touched paths.
+
+## Wiring Instructions
+Reference `mocks/MappingGraphKernel` from components needing a graph engine or
+replace with a real kernel implementation later.
+
+## Tests & Results
+- `dotnet test mocks/MappingGraphKernel.Tests` – verifies dispatch and tick logic.
+
+## Reference Used
+- reference/PERFECT/Mapping/InputRouter.cs

--- a/GaymController/tasks/parallel/GC-PAR-004.md
+++ b/GaymController/tasks/parallel/GC-PAR-004.md
@@ -4,7 +4,11 @@
 Work from **interfaces/** and **mocks/** only. Keep hot paths allocation-free. **Consult `reference/` first** to understand legacy behavior/feel.
 
 ## Paths to touch
-- (fill with your implementation files)
+- interfaces/MappingGraphKernel.cs
+- mocks/MappingGraphKernel/MappingGraphKernel.cs
+- mocks/MappingGraphKernel/MappingGraphKernel.csproj
+- mocks/MappingGraphKernel.Tests/MappingGraphKernel.Tests.csproj
+- mocks/MappingGraphKernel.Tests/MappingGraphKernelTests.cs
 
 ## Reference guidelines
 - Look for any related files in `reference/originals/*`, `reference/aim/*`, or `reference/traces/*`.


### PR DESCRIPTION
## Summary
- define `IMappingGraphKernel` interface for allocation-free node graph operations
- add in-memory mock `MappingGraphKernel` and xUnit tests
- record mapping graph paths and test run in GC-PAR-004 report

## Testing
- `dotnet test mocks/MappingGraphKernel.Tests -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689bc7257f6c8320b72112fb4fb5201c