### PR TITLE
Implement App sink and mock broker test harness

### DIFF
--- a/GaymController/interfaces/AppSink/AppSink.cs
+++ b/GaymController/interfaces/AppSink/AppSink.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using GaymController.Shared.Contracts;
+
+namespace GaymController.Interfaces;
+
+/// <summary>
+/// Minimal client used by the app to send controller state to the broker.
+/// </summary>
+public sealed class AppSink : IAsyncDisposable
+{
+    private readonly Stream _stream;
+    private readonly byte[] _stateBuf;
+    private ulong _handle;
+
+    private const int StatePayloadBytes = 8 + 16; // handle + GamepadState
+
+    public AppSink(Stream stream)
+    {
+        _stream = stream;
+        _stateBuf = Wire.Rent(Wire.HeaderBytes + StatePayloadBytes);
+        Wire.WriteHeader(_stateBuf, StatePayloadBytes, 20); // SET_STATE frame
+    }
+
+    public async Task HandshakeAsync(CancellationToken ct = default)
+    {
+        byte[] buf = Wire.Rent(Wire.HeaderBytes + 4);
+        try
+        {
+            Wire.WriteHeader(buf, 4, 1); // HELLO
+            BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(Wire.HeaderBytes), 1);
+            await _stream.WriteAsync(buf.AsMemory(0, Wire.HeaderBytes + 4), ct).ConfigureAwait(false);
+
+            await _stream.ReadExactlyAsync(buf.AsMemory(0, Wire.HeaderBytes + 4), ct).ConfigureAwait(false);
+        }
+        finally { Wire.Return(buf); }
+    }
+
+    public async Task OpenAsync(uint slot, CancellationToken ct = default)
+    {
+        byte[] buf = Wire.Rent(Wire.HeaderBytes + 4);
+        try
+        {
+            Wire.WriteHeader(buf, 4, 10); // OPEN_CONTROLLER
+            BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(Wire.HeaderBytes), slot);
+            await _stream.WriteAsync(buf.AsMemory(0, Wire.HeaderBytes + 4), ct).ConfigureAwait(false);
+
+            await _stream.ReadExactlyAsync(buf.AsMemory(0, Wire.HeaderBytes + 8), ct).ConfigureAwait(false);
+            _handle = BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(Wire.HeaderBytes));
+        }
+        finally { Wire.Return(buf); }
+    }
+
+    public async ValueTask SetStateAsync(GamepadState state, CancellationToken ct = default)
+    {
+        BinaryPrimitives.WriteUInt64LittleEndian(_stateBuf.AsSpan(Wire.HeaderBytes), _handle);
+        MemoryMarshal.Write(_stateBuf.AsSpan(Wire.HeaderBytes + 8), ref state);
+        await _stream.WriteAsync(_stateBuf.AsMemory(0, Wire.HeaderBytes + StatePayloadBytes), ct).ConfigureAwait(false);
+        await _stream.ReadExactlyAsync(_stateBuf.AsMemory(0, Wire.HeaderBytes + 4), ct).ConfigureAwait(false);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Wire.Return(_stateBuf);
+        _stream.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/GaymController/interfaces/AppSink/AppSink.csproj
+++ b/GaymController/interfaces/AppSink/AppSink.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../shared/Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/GaymController/mocks/MockBroker.Tests/AppSinkBrokerTests.cs
+++ b/GaymController/mocks/MockBroker.Tests/AppSinkBrokerTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO.Pipes;
+using System.Threading.Tasks;
+using GaymController.Interfaces;
+using GaymController.Mocks;
+using GaymController.Shared.Contracts;
+using Xunit;
+
+public class AppSinkBrokerTests
+{
+    [Fact]
+    public async Task State_Flow_Reaches_MockBroker()
+    {
+        string pipe = "gc_test_" + Guid.NewGuid().ToString("N");
+        await using var broker = new MockBroker(pipe);
+        var serverTask = broker.StartAsync();
+
+        using var client = new NamedPipeClientStream(".", pipe, PipeDirection.InOut, PipeOptions.Asynchronous);
+        await client.ConnectAsync(2000);
+        await serverTask; // ensure server loop is running
+
+        await using var sink = new AppSink(client);
+        await sink.HandshakeAsync();
+        await sink.OpenAsync(0);
+
+        var state = new GamepadState { LX=1, LY=2, RX=3, RY=4, LT=5, RT=6, Buttons=7 };
+        await sink.SetStateAsync(state);
+
+        Assert.Equal(state, broker.LastState);
+    }
+}

--- a/GaymController/mocks/MockBroker.Tests/MockBroker.Tests.csproj
+++ b/GaymController/mocks/MockBroker.Tests/MockBroker.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../interfaces/AppSink/AppSink.csproj" />
+    <ProjectReference Include="../MockBroker/MockBroker.csproj" />
+  </ItemGroup>
+</Project>

--- a/GaymController/mocks/MockBroker/MockBroker.cs
+++ b/GaymController/mocks/MockBroker/MockBroker.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using GaymController.Shared.Contracts;
+
+namespace GaymController.Mocks;
+
+/// <summary>
+/// Minimal broker emulator for integration tests.
+/// </summary>
+public sealed class MockBroker : IAsyncDisposable
+{
+    private readonly NamedPipeServerStream _server;
+    private readonly CancellationTokenSource _cts = new();
+    public GamepadState LastState;
+
+    public MockBroker(string pipeName)
+    {
+        _server = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+    }
+
+    public async Task StartAsync()
+    {
+        await _server.WaitForConnectionAsync(_cts.Token).ConfigureAwait(false);
+        _ = Task.Run(() => RunAsync(_cts.Token));
+    }
+
+    private async Task RunAsync(CancellationToken ct)
+    {
+        var header = new byte[Wire.HeaderBytes];
+        while (!ct.IsCancellationRequested)
+        {
+            await _server.ReadExactlyAsync(header, ct).ConfigureAwait(false);
+            uint len = BinaryPrimitives.ReadUInt32LittleEndian(header);
+            ushort type = BinaryPrimitives.ReadUInt16LittleEndian(header.AsSpan(4));
+            var payload = new byte[len];
+            await _server.ReadExactlyAsync(payload, ct).ConfigureAwait(false);
+
+            switch (type)
+            {
+                case 1: // HELLO
+                {
+                    var res = new byte[Wire.HeaderBytes + 4];
+                    Wire.WriteHeader(res, 4, 2); // HELLO_OK
+                    BinaryPrimitives.WriteUInt32LittleEndian(res.AsSpan(Wire.HeaderBytes), 1);
+                    await _server.WriteAsync(res, ct).ConfigureAwait(false);
+                    break;
+                }
+                case 10: // OPEN_CONTROLLER
+                {
+                    var res = new byte[Wire.HeaderBytes + 8];
+                    Wire.WriteHeader(res, 8, 11); // OPEN_OK
+                    BinaryPrimitives.WriteUInt64LittleEndian(res.AsSpan(Wire.HeaderBytes), 1);
+                    await _server.WriteAsync(res, ct).ConfigureAwait(false);
+                    break;
+                }
+                case 20: // SET_STATE
+                {
+                    LastState = MemoryMarshal.Read<GamepadState>(payload.AsSpan(8));
+                    var ack = new byte[Wire.HeaderBytes + 4];
+                    Wire.WriteHeader(ack, 4, 21); // ACK
+                    BinaryPrimitives.WriteUInt32LittleEndian(ack.AsSpan(Wire.HeaderBytes), 20);
+                    await _server.WriteAsync(ack, ct).ConfigureAwait(false);
+                    break;
+                }
+                default:
+                    return;
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _cts.Cancel();
+        await _server.DisposeAsync();
+        _cts.Dispose();
+    }
+}

--- a/GaymController/mocks/MockBroker/MockBroker.csproj
+++ b/GaymController/mocks/MockBroker/MockBroker.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../shared/Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/GaymController/reports/GC-PAR-002.json
+++ b/GaymController/reports/GC-PAR-002.json
@@ -6,7 +6,7 @@
   "reference": {
     "consulted": true,
     "files": ["reference/k/tests/VPadBroker.Tests/BrokerTests.cs"],
-    "notes": "Reviewed original broker tests to mirror IPC flow"
+    "notes": "Used wire.json to map message types"
   },
   "files": [
     "interfaces/AppSink/AppSink.cs",
@@ -17,7 +17,7 @@
     "mocks/MockBroker.Tests/AppSinkBrokerTests.cs"
   ],
   "wiring": {
-    "how_to_hook": "Wrap a NamedPipe stream with AppSink to talk to the broker; use MockBroker in tests"
+    "how_to_hook": "Wrap a NamedPipe stream with AppSink to communicate with a broker; MockBroker provides a test server"
   },
   "results": {
     "notes": "xUnit test confirms state delivery"

--- a/GaymController/reports/GC-PAR-002.md
+++ b/GaymController/reports/GC-PAR-002.md
@@ -1,0 +1,25 @@
+# GC-PAR-002 — App Sink ↔ Mock Broker
+
+## Summary
+Implemented a minimal AppSink that speaks the wire protocol and a MockBroker used for integration tests.
+
+## Interfaces/Contracts
+- `interfaces/wire.json` message definitions
+- `Shared.Contracts.GamepadState`
+
+## Files Changed
+- interfaces/AppSink/AppSink.cs: broker client with handshake, open and state send.
+- interfaces/AppSink/AppSink.csproj: project file.
+- mocks/MockBroker/MockBroker.cs: pipe-based broker emulator recording last state.
+- mocks/MockBroker/MockBroker.csproj: project file.
+- mocks/MockBroker.Tests/MockBroker.Tests.csproj: xUnit test project wiring sink and mock.
+- mocks/MockBroker.Tests/AppSinkBrokerTests.cs: verifies state reaches mock broker.
+
+## Wiring Instructions
+Create a `NamedPipeClientStream`, wrap it with `AppSink`, call `HandshakeAsync` then `OpenAsync`, and push controller updates with `SetStateAsync`. For tests, `MockBroker` exposes a pipe server on the same name.
+
+## Tests & Results
+- `dotnet test mocks/MockBroker.Tests/MockBroker.Tests.csproj`
+
+## Reference Used
+- `reference/k/tests/VPadBroker.Tests/BrokerTests.cs`

--- a/GaymController/tasks/parallel/GC-PAR-002.md
+++ b/GaymController/tasks/parallel/GC-PAR-002.md
@@ -4,7 +4,12 @@
 Work from **interfaces/** and **mocks/** only. Keep hot paths allocation-free. **Consult `reference/` first** to understand legacy behavior/feel.
 
 ## Paths to touch
-- (fill with your implementation files)
+- interfaces/AppSink/AppSink.cs
+- interfaces/AppSink/AppSink.csproj
+- mocks/MockBroker/MockBroker.cs
+- mocks/MockBroker/MockBroker.csproj
+- mocks/MockBroker.Tests/MockBroker.Tests.csproj
+- mocks/MockBroker.Tests/AppSinkBrokerTests.cs
 
 ## Reference guidelines
 - Look for any related files in `reference/originals/*`, `reference/aim/*`, or `reference/traces/*`.


### PR DESCRIPTION
## Summary
- add `AppSink` client for broker handshake, open and state sending
- create `MockBroker` to emulate broker responses
- add xUnit test verifying state reaches mock broker

## Testing
- `dotnet test GaymController/mocks/MockBroker.Tests/MockBroker.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689bc7135fc88320906d30ec05bdaa14