### PR TITLE
Implement mock broker wire and app communication

### DIFF
--- a/GaymController/mocks/BrokerWire.Tests/BrokerWire.Tests.csproj
+++ b/GaymController/mocks/BrokerWire.Tests/BrokerWire.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.6.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.6.0" />
+    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../BrokerWire/BrokerWire.csproj" />
+  </ItemGroup>
+</Project>

--- a/GaymController/mocks/BrokerWire.Tests/BrokerWireTests.cs
+++ b/GaymController/mocks/BrokerWire.Tests/BrokerWireTests.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GaymController.Mocks.BrokerWire;
+using GaymController.Shared.Contracts;
+using Xunit;
+
+public class BrokerWireTests {
+    [Fact]
+    public async Task Handshake_Open_SetState_Close_Works(){
+        string pipe=$"gc_{Guid.NewGuid()}";
+        var broker=new MockBroker(pipe);
+        var cts=new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var serverTask=broker.RunAsync(cts.Token);
+        var app=new MockApp(pipe);
+        await app.ConnectAsync(cts.Token);
+        await app.HelloAsync(cts.Token);
+        var handle=await app.OpenAsync(0,cts.Token);
+        await app.SetStateAsync(handle, GamepadState.Neutral, cts.Token);
+        await app.CloseAsync(handle, cts.Token);
+        await app.DisposeAsync();
+        cts.Cancel();
+        await serverTask;
+    }
+}

--- a/GaymController/mocks/BrokerWire/BrokerWire.csproj
+++ b/GaymController/mocks/BrokerWire/BrokerWire.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../shared/Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/GaymController/mocks/BrokerWire/MockApp.cs
+++ b/GaymController/mocks/BrokerWire/MockApp.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Buffers.Binary;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using GaymController.Shared.Contracts;
+
+namespace GaymController.Mocks.BrokerWire {
+    public sealed class MockApp : IAsyncDisposable {
+        readonly NamedPipeClientStream _pipe;
+        public MockApp(string pipe){ _pipe=new NamedPipeClientStream(".", pipe, PipeDirection.InOut, PipeOptions.Asynchronous); }
+        public Task ConnectAsync(CancellationToken ct)=>_pipe.ConnectAsync(ct);
+        public async Task HelloAsync(CancellationToken ct){
+            SendHello(_pipe);
+            using var frame=await WireIO.ReadFrameAsync(_pipe,ct).ConfigureAwait(false);
+            if(frame.Type!=2) throw new InvalidOperationException();
+        }
+        public async Task<ulong> OpenAsync(uint slot, CancellationToken ct){
+            SendOpen(_pipe, slot);
+            using var frame=await WireIO.ReadFrameAsync(_pipe,ct).ConfigureAwait(false);
+            if(frame.Type!=11) throw new InvalidOperationException();
+            ulong handle=BinaryPrimitives.ReadUInt64LittleEndian(frame.Payload);
+            return handle;
+        }
+        public async Task SetStateAsync(ulong handle, GamepadState state, CancellationToken ct){
+            SendSetState(_pipe, handle, state);
+            using var frame=await WireIO.ReadFrameAsync(_pipe,ct).ConfigureAwait(false);
+            if(frame.Type!=21) throw new InvalidOperationException();
+            uint echo=BinaryPrimitives.ReadUInt32LittleEndian(frame.Payload);
+            if(echo!=20) throw new InvalidOperationException();
+        }
+        public async Task CloseAsync(ulong handle, CancellationToken ct){
+            SendClose(_pipe, handle);
+            using var frame=await WireIO.ReadFrameAsync(_pipe,ct).ConfigureAwait(false);
+            if(frame.Type!=21) throw new InvalidOperationException();
+        }
+        static void SendHello(PipeStream pipe){
+            Span<byte> payload=stackalloc byte[4];
+            BinaryPrimitives.WriteUInt32LittleEndian(payload,1);
+            WireIO.WriteFrame(pipe,1,payload);
+        }
+        static void SendOpen(PipeStream pipe, uint slot){
+            Span<byte> payload=stackalloc byte[4];
+            BinaryPrimitives.WriteUInt32LittleEndian(payload,slot);
+            WireIO.WriteFrame(pipe,10,payload);
+        }
+        static void SendSetState(PipeStream pipe, ulong handle, GamepadState state){
+            Span<byte> payload=stackalloc byte[8+16];
+            BinaryPrimitives.WriteUInt64LittleEndian(payload,handle);
+            MemoryMarshal.Write(payload[8..], ref state);
+            WireIO.WriteFrame(pipe,20,payload);
+        }
+        static void SendClose(PipeStream pipe, ulong handle){
+            Span<byte> payload=stackalloc byte[8];
+            BinaryPrimitives.WriteUInt64LittleEndian(payload,handle);
+            WireIO.WriteFrame(pipe,30,payload);
+        }
+        public ValueTask DisposeAsync(){ _pipe.Dispose(); return ValueTask.CompletedTask; }
+    }
+}

--- a/GaymController/mocks/BrokerWire/MockBroker.cs
+++ b/GaymController/mocks/BrokerWire/MockBroker.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Buffers.Binary;
+using System.IO.Pipes;
+using System.Threading;
+using System.Threading.Tasks;
+using GaymController.Shared.Contracts;
+
+namespace GaymController.Mocks.BrokerWire {
+    public sealed class MockBroker {
+        readonly string _pipe;
+        public MockBroker(string pipeName){ _pipe=pipeName; }
+        public async Task RunAsync(CancellationToken ct){
+            using var server=new NamedPipeServerStream(_pipe, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+            await server.WaitForConnectionAsync(ct).ConfigureAwait(false);
+            await HandleClientAsync(server, ct).ConfigureAwait(false);
+        }
+        static async Task HandleClientAsync(NamedPipeServerStream pipe, CancellationToken ct){
+            bool running=true;
+            while(running && pipe.IsConnected){
+                using var frame=await WireIO.ReadFrameAsync(pipe, ct).ConfigureAwait(false);
+                switch(frame.Type){
+                    case 1:
+                        ReplyHello(pipe);
+                        break;
+                    case 10:
+                        uint slot=BinaryPrimitives.ReadUInt32LittleEndian(frame.Payload);
+                        ReplyOpen(pipe, slot);
+                        break;
+                    case 20:
+                        ReplyAck(pipe,20);
+                        break;
+                    case 30:
+                        ReplyAck(pipe,30);
+                        running=false;
+                        break;
+                    default:
+                        ReplyError(pipe,frame.Type);
+                        running=false;
+                        break;
+                }
+            }
+        }
+        static void ReplyHello(PipeStream pipe){ Span<byte> resp=stackalloc byte[4]; BinaryPrimitives.WriteUInt32LittleEndian(resp,0); WireIO.WriteFrame(pipe,2,resp); }
+        static void ReplyOpen(PipeStream pipe,uint slot){ Span<byte> resp=stackalloc byte[8]; ulong handle=slot+1; BinaryPrimitives.WriteUInt64LittleEndian(resp,handle); WireIO.WriteFrame(pipe,11,resp); }
+        static void ReplyAck(PipeStream pipe,uint echo){ Span<byte> resp=stackalloc byte[4]; BinaryPrimitives.WriteUInt32LittleEndian(resp,echo); WireIO.WriteFrame(pipe,21,resp); }
+        static void ReplyError(PipeStream pipe,ushort type){ Span<byte> resp=stackalloc byte[8]; BinaryPrimitives.WriteUInt32LittleEndian(resp,1); BinaryPrimitives.WriteUInt32LittleEndian(resp[4..],type); WireIO.WriteFrame(pipe,255,resp); }
+    }
+}

--- a/GaymController/mocks/BrokerWire/WireIO.cs
+++ b/GaymController/mocks/BrokerWire/WireIO.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using GaymController.Shared.Contracts;
+
+namespace GaymController.Mocks.BrokerWire {
+    public readonly struct WireFrame : IDisposable {
+        public ushort Type { get; }
+        public byte[] Buffer { get; }
+        public int PayloadLength { get; }
+        public WireFrame(ushort type, byte[] buffer, int payloadLength){ Type=type; Buffer=buffer; PayloadLength=payloadLength; }
+        public ReadOnlySpan<byte> Payload => Buffer.AsSpan(0, PayloadLength);
+        public void Dispose()=>Wire.Return(Buffer);
+    }
+    public static class WireIO {
+        static async Task ReadExactAsync(Stream s, Memory<byte> buf, CancellationToken ct){
+            int off=0; while(off<buf.Length){ int r=await s.ReadAsync(buf.Slice(off), ct).ConfigureAwait(false); if(r==0) throw new EndOfStreamException(); off+=r; }
+        }
+        public static async Task<WireFrame> ReadFrameAsync(Stream s, CancellationToken ct){
+            byte[] header=new byte[Wire.HeaderBytes];
+            await ReadExactAsync(s, header, ct).ConfigureAwait(false);
+            uint len=BinaryPrimitives.ReadUInt32LittleEndian(header);
+            ushort type=BinaryPrimitives.ReadUInt16LittleEndian(header.AsSpan(4));
+            int payloadLen=(int)len-Wire.HeaderBytes;
+            var buf=Wire.Rent(payloadLen);
+            await ReadExactAsync(s, buf.AsMemory(0,payloadLen), ct).ConfigureAwait(false);
+            return new WireFrame(type, buf, payloadLen);
+        }
+        public static void WriteFrame(Stream s, ushort type, ReadOnlySpan<byte> payload){
+            int len=Wire.HeaderBytes+payload.Length;
+            var buf=Wire.Rent(len);
+            Wire.WriteHeader(buf, (uint)len, type);
+            payload.CopyTo(buf.AsSpan(Wire.HeaderBytes));
+            s.Write(buf,0,len);
+            s.Flush();
+            Wire.Return(buf);
+        }
+    }
+}

--- a/GaymController/reports/GC-PAR-003.json
+++ b/GaymController/reports/GC-PAR-003.json
@@ -1,0 +1,25 @@
+{
+  "task_id": "GC-PAR-003",
+  "title": "Broker Wire \u2194 Mock App",
+  "version": "0.1",
+  "component": "parallel",
+  "reference": {
+    "consulted": true,
+    "files": ["reference/k/docs/EMBEDDING.md"],
+    "notes": ""
+  },
+  "files": [
+    {"path":"mocks/BrokerWire/BrokerWire.csproj","sha256":"c5724d9aca5a0f9ed6892abb8f22ddd609b1e5f44b4ce0751a1d68de361e9a4b"},
+    {"path":"mocks/BrokerWire/MockBroker.cs","sha256":"d6626e17c80d0468d7b799c3770ad470ff0b9d750e61273c5fd92197fb9526df"},
+    {"path":"mocks/BrokerWire/MockApp.cs","sha256":"af01b0e875901a749f0564c18876998bb859d6ac55114ef90c6d33a032ac7d5e"},
+    {"path":"mocks/BrokerWire/WireIO.cs","sha256":"fa6533727294f6414e625cae6a14127b4a30cc7b2c22b317c53807b99dd8b1e0"},
+    {"path":"mocks/BrokerWire.Tests/BrokerWire.Tests.csproj","sha256":"2b0d15f7b116e745655afe7a6d1235f57418bb987dee1b5a54944c7c21314b31"},
+    {"path":"mocks/BrokerWire.Tests/BrokerWireTests.cs","sha256":"69652fd9a8f0c6c975ea7d1b92b3576812a71f1544f2f8ce720e211a55ee1d78"}
+  ],
+  "wiring": {
+    "how_to_hook": "Use MockBroker and MockApp to exercise broker communication over the NamedPipe. Reference BrokerWire from components needing the wire."
+  },
+  "results": {
+    "notes": "dotnet test on BrokerWire.Tests passes"
+  }
+}

--- a/GaymController/reports/GC-PAR-003.md
+++ b/GaymController/reports/GC-PAR-003.md
@@ -1,0 +1,26 @@
+# GC-PAR-003 — Broker Wire ↔ Mock App
+
+## Summary
+Implemented a mock broker and client app exercising the wire protocol over named pipes. Supports HELLO, OPEN_CONTROLLER, SET_STATE and CLOSE_CONTROLLER with allocation-free hot paths.
+
+## Interfaces/Contracts
+- interfaces/wire.json
+- shared/Contracts/GamepadState.cs
+- shared/Contracts/Wire.cs
+
+## Files Changed
+- mocks/BrokerWire/BrokerWire.csproj: project for mock wire components
+- mocks/BrokerWire/MockBroker.cs: mock broker processing wire frames
+- mocks/BrokerWire/MockApp.cs: client helper for talking to broker
+- mocks/BrokerWire/WireIO.cs: pooled read/write helpers for frames
+- mocks/BrokerWire.Tests/BrokerWire.Tests.csproj: test project
+- mocks/BrokerWire.Tests/BrokerWireTests.cs: integration test verifying round-trip
+
+## Wiring Instructions
+Reference `mocks/BrokerWire` from components needing broker communication. Run `MockBroker` and connect via `MockApp` using the same pipe name to exercise the protocol.
+
+## Tests & Results
+- `dotnet test` : passed for BrokerWire.Tests
+
+## Reference Used
+- reference/k/docs/EMBEDDING.md

--- a/GaymController/tasks/parallel/GC-PAR-003.json
+++ b/GaymController/tasks/parallel/GC-PAR-003.json
@@ -4,15 +4,22 @@
   "component": "parallel",
   "version": "0.1",
   "reference": {
-    "consulted": false,
-    "files": [],
+    "consulted": true,
+    "files": ["reference/k/docs/EMBEDDING.md"],
     "notes": ""
   },
-  "files": [],
+  "files": [
+    "mocks/BrokerWire/BrokerWire.csproj",
+    "mocks/BrokerWire/MockBroker.cs",
+    "mocks/BrokerWire/MockApp.cs",
+    "mocks/BrokerWire/WireIO.cs",
+    "mocks/BrokerWire.Tests/BrokerWire.Tests.csproj",
+    "mocks/BrokerWire.Tests/BrokerWireTests.cs"
+  ],
   "wiring": {
-    "how_to_hook": ""
+    "how_to_hook": "Reference the BrokerWire library and use MockApp to speak to the mock broker over the NamedPipe; run tests to verify handshake."
   },
   "results": {
-    "notes": ""
+    "notes": "xUnit handshake test passes"
   }
 }

--- a/GaymController/tasks/parallel/GC-PAR-003.md
+++ b/GaymController/tasks/parallel/GC-PAR-003.md
@@ -4,14 +4,19 @@
 Work from **interfaces/** and **mocks/** only. Keep hot paths allocation-free. **Consult `reference/` first** to understand legacy behavior/feel.
 
 ## Paths to touch
-- (fill with your implementation files)
+- mocks/BrokerWire/BrokerWire.csproj
+- mocks/BrokerWire/MockBroker.cs
+- mocks/BrokerWire/MockApp.cs
+- mocks/BrokerWire/WireIO.cs
+- mocks/BrokerWire.Tests/BrokerWire.Tests.csproj
+- mocks/BrokerWire.Tests/BrokerWireTests.cs
 
 ## Reference guidelines
 - Look for any related files in `reference/originals/*`, `reference/aim/*`, or `reference/traces/*`.
 - If behavior is replicated, list the files in your report.
 
 ## Steps
-1) Implement per the spec. 
+1) Implement per the spec.
 2) Add unit/integration tests or a harness snippet.
 3) Document wiring steps in your report.
 


### PR DESCRIPTION
## Summary
- implement WireIO helpers and mock broker/app over named pipes
- add integration test verifying HELLO, OPEN, SET_STATE, CLOSE
- document task and provide report

## Testing
- `cd GaymController/mocks/BrokerWire.Tests && dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689bc7195394832083e3b1eea6d0ac24