### PR TITLE
GC-W-002: add Wooting HID enumeration

### DIFF
--- a/GaymController/reports/GC-W-002.json
+++ b/GaymController/reports/GC-W-002.json
@@ -1,0 +1,23 @@
+{
+  "task_id": "GC-W-002",
+  "title": "HID Enumeration & Path Selection",
+  "version": "0.1",
+  "component": "wooting",
+  "reference": {
+    "consulted": false,
+    "files": [],
+    "notes": ""
+  },
+  "files": [
+    {"path": "src/GaymController.Wooting/GaymController.Wooting.csproj"},
+    {"path": "src/GaymController.Wooting/RawHidProvider.cs"},
+    {"path": "src/GaymController.Wooting.Tests/RawHidProviderTests.cs"},
+    {"path": "reports/GC-W-002.md"}
+  ],
+  "wiring": {
+    "how_to_hook": "Instantiate RawHidProvider and call Start(); it selects the first supported device path via EnumerateDevicePaths."
+  },
+  "results": {
+    "notes": "dotnet test"
+  }
+}

--- a/GaymController/reports/GC-W-002.md
+++ b/GaymController/reports/GC-W-002.md
@@ -1,0 +1,23 @@
+# GC-W-002 — HID Enumeration & Path Selection
+
+## Summary
+Implemented raw HID enumeration for Wooting keyboards using HidSharp and added path selection logic.
+
+## Interfaces/Contracts
+- `RawHidProvider.IsSupportedDevice(int vid, int pid)` — identifies supported VID/PID pairs.
+- `RawHidProvider.EnumerateDevicePaths()` — yields device paths for supported keyboards.
+
+## Files Changed
+- `src/GaymController.Wooting/GaymController.Wooting.csproj`: added HidSharp dependency and multi-targeting.
+- `src/GaymController.Wooting/RawHidProvider.cs`: implemented enumeration, path selection, and start/stop logic.
+- `src/GaymController.Wooting.Tests/*`: added unit tests for VID/PID filtering.
+
+## Wiring Instructions
+Instantiate `RawHidProvider` and call `Start()`; the provider selects the first supported device via `EnumerateDevicePaths()`.
+
+## Tests & Results
+- `dotnet test` — verifies VID/PID filtering logic.
+
+## Reference Used
+None
+

--- a/GaymController/reports/WIRING_GUIDE.md
+++ b/GaymController/reports/WIRING_GUIDE.md
@@ -1,0 +1,16 @@
+# WIRING GUIDE
+
+## GC-W-002 — HID Enumeration & Path Selection
+
+**Component:** wooting  
+**Reference consulted:** False  
+### Wiring Instructions
+
+Instantiate RawHidProvider and call Start(); it selects the first supported device path via EnumerateDevicePaths.
+
+### Files
+
+- `src/GaymController.Wooting/GaymController.Wooting.csproj`  `2f24bbcf2c3d5124d1befdb43f55bedfa208fc8a1f74e7a5aabf09a9b438cee5`
+- `src/GaymController.Wooting/RawHidProvider.cs`  `21b339f50132f99dd037e281ac53786920ec6dab00a135d4678bd2417bce137e`
+- `src/GaymController.Wooting.Tests/RawHidProviderTests.cs`  `fce9872d03a86de684d59fa15ab40bfcdb4c310070431b5d2ee523b241bc7621`
+- `reports/GC-W-002.md`  `a41368b7c6de6d2a8176bb65f85dfd0c920208000a964dd356af4ad1872168c5`

--- a/GaymController/src/GaymController.Wooting.Tests/GaymController.Wooting.Tests.csproj
+++ b/GaymController/src/GaymController.Wooting.Tests/GaymController.Wooting.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GaymController.Wooting\GaymController.Wooting.csproj" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+  </ItemGroup>
+</Project>

--- a/GaymController/src/GaymController.Wooting.Tests/RawHidProviderTests.cs
+++ b/GaymController/src/GaymController.Wooting.Tests/RawHidProviderTests.cs
@@ -1,0 +1,15 @@
+using GaymController.Wooting;
+using Xunit;
+
+namespace GaymController.Wooting.Tests {
+    public class RawHidProviderTests {
+        [Theory]
+        [InlineData(0x31E3, 0x1100, true)]
+        [InlineData(0x31E3, 0x1200, true)]
+        [InlineData(0x31E3, 0x9999, false)]
+        [InlineData(0xFFFF, 0x1100, false)]
+        public void IsSupportedDeviceFiltersByVidPid(int vid, int pid, bool expected) {
+            Assert.Equal(expected, RawHidProvider.IsSupportedDevice(vid, pid));
+        }
+    }
+}

--- a/GaymController/src/GaymController.Wooting/GaymController.Wooting.csproj
+++ b/GaymController/src/GaymController.Wooting/GaymController.Wooting.csproj
@@ -1,9 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <!-- Multi-target so test project can run cross-platform -->
+    <TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\shared\Shared.csproj" />
+    <!-- HidSharp provides cross-platform HID enumeration without vendor SDK -->
+    <PackageReference Include="HidSharp" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/GaymController/src/GaymController.Wooting/RawHidProvider.cs
+++ b/GaymController/src/GaymController.Wooting/RawHidProvider.cs
@@ -1,11 +1,45 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using GaymController.Shared.Mapping;
+using HidSharp;
 
 namespace GaymController.Wooting {
-    // Stub - implement overlapped HID reads + mapping file application
+    // Raw HID provider using HidSharp for device enumeration.
     public sealed class RawHidProvider : IWootingProvider {
         public event EventHandler<InputEvent>? OnKeyAnalog;
-        public void Start(){ /* TODO */ } public void Stop(){ /* TODO */ }
-        public void Dispose(){ Stop(); }
+
+        public const int VendorId = 0x31E3;
+        static readonly HashSet<int> SupportedProductIds = new() { 0x1100, 0x1200, 0x1210, 0x1220 };
+
+        HidStream? _stream;
+
+        /// <summary>Checks whether the VID/PID pair represents a supported Wooting keyboard.</summary>
+        public static bool IsSupportedDevice(int vendorId, int productId) =>
+            vendorId == VendorId && SupportedProductIds.Contains(productId);
+
+        /// <summary>Enumerate raw HID device paths for supported Wooting keyboards.</summary>
+        public static IEnumerable<string> EnumerateDevicePaths() {
+            foreach (var device in DeviceList.Local.GetHidDevices()) {
+                if (IsSupportedDevice(device.VendorID, device.ProductID)) {
+                    yield return device.DevicePath;
+                }
+            }
+        }
+
+        public void Start() {
+            if (_stream != null) { return; }
+            var device = DeviceList.Local.GetHidDevices()
+                .FirstOrDefault(d => IsSupportedDevice(d.VendorID, d.ProductID));
+            if (device == null) { return; }
+            _stream = device.Open();
+        }
+
+        public void Stop() {
+            _stream?.Dispose();
+            _stream = null;
+        }
+
+        public void Dispose() { Stop(); }
     }
 }

--- a/GaymController/tasks/wooting/GC-W-002.json
+++ b/GaymController/tasks/wooting/GC-W-002.json
@@ -8,11 +8,15 @@
     "files": [],
     "notes": ""
   },
-  "files": [],
+  "files": [
+    "src/GaymController.Wooting/GaymController.Wooting.csproj",
+    "src/GaymController.Wooting/RawHidProvider.cs",
+    "src/GaymController.Wooting.Tests/RawHidProviderTests.cs"
+  ],
   "wiring": {
-    "how_to_hook": ""
+    "how_to_hook": "Instantiate RawHidProvider and call Start to select a Wooting HID path."
   },
   "results": {
-    "notes": ""
+    "notes": "dotnet test"
   }
 }


### PR DESCRIPTION
## Summary
- use HidSharp to enumerate Wooting HID devices
- expose device-path selection and start/stop lifecycle
- add tests for VID/PID filtering

## Testing
- `dotnet test src/GaymController.Wooting.Tests/GaymController.Wooting.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689bc73353608320ae869fad05fa72b1