### PR TITLE
Implement wire message packer with golden frame tests

### DIFF
--- a/GaymController/reports/GC-PAR-001.json
+++ b/GaymController/reports/GC-PAR-001.json
@@ -1,0 +1,22 @@
+{
+  "task_id": "GC-PAR-001",
+  "title": "Wire Pack (C#) + Golden Frames",
+  "component": "parallel",
+  "version": "0.1",
+  "reference": {
+    "consulted": true,
+    "files": ["reference/README.md"],
+    "notes": ""
+  },
+  "files": [
+    {"path":"shared/Contracts/Wire.cs","sha256":"d5a89821c1cefc9184ba2bcd8cbdb12b0a404fce0d014d8a67e69d5e8f17d6cf"},
+    {"path":"tests/WireTests/WirePackTests.cs","sha256":"2d1b1a838e210e5ba4ede2054ed6692b7890ac9186f0dfbaa5414d8d4cd2640f"},
+    {"path":"tests/WireTests/WireTests.csproj","sha256":"cd18e54ad44e6ec583ecc4d7b5c0e0b876aa370fa562172868ca731f2a14d20c"}
+  ],
+  "wiring": {
+    "how_to_hook": "Use Wire.Pack* helpers to serialize messages prior to writing them to the broker pipe."
+  },
+  "results": {
+    "notes": "dotnet test tests/WireTests/WireTests.csproj"
+  }
+}

--- a/GaymController/reports/GC-PAR-001.md
+++ b/GaymController/reports/GC-PAR-001.md
@@ -1,0 +1,22 @@
+# GC-PAR-001 — Wire Pack (C#) + Golden Frames
+
+## Summary
+Implemented C# wire message packers for all protocol types and added golden frame unit tests.
+
+## Interfaces/Contracts
+- shared/Contracts/Wire.cs
+
+## Files Changed
+- shared/Contracts/Wire.cs: added `MsgType` enum and packing helpers.
+- tests/WireTests/WirePackTests.cs: golden frame tests for hello, state, and rumble.
+- tests/WireTests/WireTests.csproj: xUnit test project referencing Shared.
+
+## Wiring Instructions
+Call the appropriate `Wire.Pack*` method with a span buffer before sending frames over the broker pipe.
+
+## Tests & Results
+- `dotnet test tests/WireTests/WireTests.csproj`
+
+## Reference Used
+- reference/README.md
+- interfaces/wire.json

--- a/GaymController/shared/Contracts/Wire.cs
+++ b/GaymController/shared/Contracts/Wire.cs
@@ -1,18 +1,84 @@
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
-using System.Threading.Tasks;
-using System.IO.Pipes;
 
 namespace GaymController.Shared.Contracts {
+    public enum MsgType : ushort {
+        HELLO=1, HELLO_OK=2, OPEN_CONTROLLER=10, OPEN_OK=11,
+        SET_STATE=20, ACK=21, CLOSE_CONTROLLER=30,
+        RUMBLE_SUBSCRIBE=40, RUMBLE_EVENT=41, ERROR=255
+    }
     public static class Wire {
-        public const int HeaderBytes = 8; // u32 len, u16 type, u16 flags
-        public static byte[] Rent(int size) => ArrayPool<byte>.Shared.Rent(size);
-        public static void Return(byte[] buf) => ArrayPool<byte>.Shared.Return(buf);
-        public static void WriteHeader(Span<byte> dst, uint len, ushort type, ushort flags=0) {
-            BinaryPrimitives.WriteUInt32LittleEndian(dst, len);
-            BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(4), type);
-            BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(6), flags);
+        public const int HeaderBytes=8; // u32 len, u16 type, u16 flags
+        public static byte[] Rent(int size)=>ArrayPool<byte>.Shared.Rent(size);
+        public static void Return(byte[] buf)=>ArrayPool<byte>.Shared.Return(buf);
+        public static void WriteHeader(Span<byte> dst,uint len,ushort type,ushort flags=0){
+            BinaryPrimitives.WriteUInt32LittleEndian(dst,len);
+            BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(4),type);
+            BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(6),flags);
+        }
+        public static int PackHello(Span<byte> dst){
+            const int len=HeaderBytes+4; WriteHeader(dst,len,(ushort)MsgType.HELLO);
+            BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(HeaderBytes),1);
+            return len;
+        }
+        public static int PackHelloOk(Span<byte> dst,uint caps){
+            const int len=HeaderBytes+4; WriteHeader(dst,len,(ushort)MsgType.HELLO_OK);
+            BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(HeaderBytes),caps);
+            return len;
+        }
+        public static int PackOpenController(Span<byte> dst,uint slot){
+            const int len=HeaderBytes+4; WriteHeader(dst,len,(ushort)MsgType.OPEN_CONTROLLER);
+            BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(HeaderBytes),slot);
+            return len;
+        }
+        public static int PackOpenOk(Span<byte> dst,ulong handle){
+            const int len=HeaderBytes+8; WriteHeader(dst,len,(ushort)MsgType.OPEN_OK);
+            BinaryPrimitives.WriteUInt64LittleEndian(dst.Slice(HeaderBytes),handle);
+            return len;
+        }
+        public static int PackSetState(Span<byte> dst,ulong handle,GamepadState state){
+            const int len=HeaderBytes+24; WriteHeader(dst,len,(ushort)MsgType.SET_STATE);
+            var o=HeaderBytes;
+            BinaryPrimitives.WriteUInt64LittleEndian(dst.Slice(o),handle); o+=8;
+            BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(o),state.LX); o+=2;
+            BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(o),state.LY); o+=2;
+            BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(o),state.RX); o+=2;
+            BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(o),state.RY); o+=2;
+            BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(o),state.LT); o+=2;
+            BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(o),state.RT); o+=2;
+            BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(o),state.Buttons);
+            return len;
+        }
+        public static int PackAck(Span<byte> dst,uint echoType){
+            const int len=HeaderBytes+4; WriteHeader(dst,len,(ushort)MsgType.ACK);
+            BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(HeaderBytes),echoType);
+            return len;
+        }
+        public static int PackCloseController(Span<byte> dst,ulong handle){
+            const int len=HeaderBytes+8; WriteHeader(dst,len,(ushort)MsgType.CLOSE_CONTROLLER);
+            BinaryPrimitives.WriteUInt64LittleEndian(dst.Slice(HeaderBytes),handle);
+            return len;
+        }
+        public static int PackRumbleSubscribe(Span<byte> dst,ulong handle){
+            const int len=HeaderBytes+8; WriteHeader(dst,len,(ushort)MsgType.RUMBLE_SUBSCRIBE);
+            BinaryPrimitives.WriteUInt64LittleEndian(dst.Slice(HeaderBytes),handle);
+            return len;
+        }
+        public static int PackRumbleEvent(Span<byte> dst,ulong handle,ushort low,ushort high){
+            const int len=HeaderBytes+12; WriteHeader(dst,len,(ushort)MsgType.RUMBLE_EVENT);
+            var o=HeaderBytes;
+            BinaryPrimitives.WriteUInt64LittleEndian(dst.Slice(o),handle); o+=8;
+            BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(o),low); o+=2;
+            BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(o),high);
+            return len;
+        }
+        public static int PackError(Span<byte> dst,uint code,uint detail){
+            const int len=HeaderBytes+8; WriteHeader(dst,len,(ushort)MsgType.ERROR);
+            var o=HeaderBytes;
+            BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(o),code); o+=4;
+            BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(o),detail);
+            return len;
         }
     }
 }

--- a/GaymController/tasks/parallel/GC-PAR-001.md
+++ b/GaymController/tasks/parallel/GC-PAR-001.md
@@ -4,7 +4,11 @@
 Work from **interfaces/** and **mocks/** only. Keep hot paths allocation-free. **Consult `reference/` first** to understand legacy behavior/feel.
 
 ## Paths to touch
-- (fill with your implementation files)
+- shared/Contracts/Wire.cs
+- tests/WireTests/WirePackTests.cs
+- tests/WireTests/WireTests.csproj
+- reports/GC-PAR-001.md
+- reports/GC-PAR-001.json
 
 ## Reference guidelines
 - Look for any related files in `reference/originals/*`, `reference/aim/*`, or `reference/traces/*`.

--- a/GaymController/tests/WireTests/WirePackTests.cs
+++ b/GaymController/tests/WireTests/WirePackTests.cs
@@ -1,0 +1,42 @@
+using System;
+using Xunit;
+using GaymController.Shared.Contracts;
+
+namespace WireTests {
+    public class WirePackTests {
+        [Fact]
+        public void HelloFrameMatchesGolden() {
+            Span<byte> buf = stackalloc byte[12];
+            var len = Wire.PackHello(buf);
+            Assert.Equal(12, len);
+            var exp = new byte[]{0x0C,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x01,0x00,0x00,0x00};
+            Assert.True(buf.Slice(0,len).SequenceEqual(exp));
+        }
+        [Fact]
+        public void SetStateFrameMatchesGolden() {
+            Span<byte> buf = stackalloc byte[32];
+            var state = GamepadState.Neutral;
+            var len = Wire.PackSetState(buf, 0x1122334455667788, state);
+            var exp = new byte[]{
+                0x20,0x00,0x00,0x00,0x14,0x00,0x00,0x00,
+                0x88,0x77,0x66,0x55,0x44,0x33,0x22,0x11,
+                0xFF,0x7F,0xFF,0x7F,0xFF,0x7F,0xFF,0x7F,
+                0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+            };
+            Assert.Equal(exp.Length, len);
+            Assert.True(buf.Slice(0,len).SequenceEqual(exp));
+        }
+        [Fact]
+        public void RumbleEventFrameMatchesGolden() {
+            Span<byte> buf = stackalloc byte[20];
+            var len = Wire.PackRumbleEvent(buf, 0x0102030405060708, 0x0A0B, 0x0C0D);
+            var exp = new byte[]{
+                0x14,0x00,0x00,0x00,0x29,0x00,0x00,0x00,
+                0x08,0x07,0x06,0x05,0x04,0x03,0x02,0x01,
+                0x0B,0x0A,0x0D,0x0C
+            };
+            Assert.Equal(exp.Length, len);
+            Assert.True(buf.Slice(0,len).SequenceEqual(exp));
+        }
+    }
+}

--- a/GaymController/tests/WireTests/WireTests.csproj
+++ b/GaymController/tests/WireTests/WireTests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../shared/Shared.csproj" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add MsgType enum and pack helpers for all wire messages
- verify frames against golden byte sequences with xUnit tests
- document work in GC-PAR-001 report

## Testing
- `dotnet test tests/WireTests/WireTests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689bc8257da483209ee238cd32da15e6