### PR TITLE
GC-PAR-006: add functional driver IOCTL stub

### DIFF
--- a/GaymController/interfaces/gc_func_ioctl.h
+++ b/GaymController/interfaces/gc_func_ioctl.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <stdint.h>
+
+#ifndef METHOD_BUFFERED
+#define METHOD_BUFFERED 0
+#endif
+#ifndef FILE_ANY_ACCESS
+#define FILE_ANY_ACCESS 0
+#endif
+#ifndef CTL_CODE
+#define CTL_CODE(DeviceType, Function, Method, Access) \
+    (((DeviceType) << 16) | ((Access) << 14) | ((Function) << 2) | (Method))
+#endif
+
+#define FILE_DEVICE_GC 0x8009
+#define IOCTL_GC_SET_REPORT       CTL_CODE(FILE_DEVICE_GC, 0x801, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_GC_SUBSCRIBE_RUMBLE CTL_CODE(FILE_DEVICE_GC, 0x802, METHOD_BUFFERED, FILE_ANY_ACCESS)
+
+#pragma pack(push,1)
+typedef struct _GC_REPORT {
+    uint16_t LX;
+    uint16_t LY;
+    uint16_t RX;
+    uint16_t RY;
+    uint16_t LT;
+    uint16_t RT;
+    uint32_t Buttons;
+} GC_REPORT;
+#pragma pack(pop)
+

--- a/GaymController/mocks/gc_func_driver.c
+++ b/GaymController/mocks/gc_func_driver.c
@@ -1,0 +1,25 @@
+#include "../interfaces/gc_func_ioctl.h"
+#include <string.h>
+
+static GC_REPORT g_last_report;
+
+int GcFuncDeviceControl(uint32_t code, const void *inBuf, size_t inLen, void *outBuf, size_t outLen) {
+    (void)outBuf; (void)outLen;
+    switch(code) {
+        case IOCTL_GC_SET_REPORT:
+            if (inBuf && inLen >= sizeof(GC_REPORT)) {
+                memcpy(&g_last_report, inBuf, sizeof(GC_REPORT));
+                return 0;
+            }
+            return -1;
+        case IOCTL_GC_SUBSCRIBE_RUMBLE:
+            return 0; // no-op
+        default:
+            return -1;
+    }
+}
+
+const GC_REPORT* GcFuncLastReport(void) {
+    return &g_last_report;
+}
+

--- a/GaymController/mocks/gc_func_driver_test.c
+++ b/GaymController/mocks/gc_func_driver_test.c
@@ -1,0 +1,18 @@
+#include "gc_func_driver.c"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void) {
+    GC_REPORT r = {1,2,3,4,5,6,7};
+    int ret = GcFuncDeviceControl(IOCTL_GC_SET_REPORT, &r, sizeof(r), NULL, 0);
+    assert(ret == 0);
+    const GC_REPORT *last = GcFuncLastReport();
+    assert(memcmp(last, &r, sizeof(r)) == 0);
+    ret = GcFuncDeviceControl(IOCTL_GC_SUBSCRIBE_RUMBLE, NULL, 0, NULL, 0);
+    assert(ret == 0);
+    ret = GcFuncDeviceControl(0xDEADBEEF, NULL, 0, NULL, 0);
+    assert(ret == -1);
+    printf("ok\n");
+    return 0;
+}

--- a/GaymController/reports/GC-PAR-006.json
+++ b/GaymController/reports/GC-PAR-006.json
@@ -1,0 +1,25 @@
+{
+  "task_id": "GC-PAR-006",
+  "title": "Func Driver IOCTL Stub",
+  "version": "0.1",
+  "component": "parallel",
+  "reference": {
+    "consulted": true,
+    "files": [
+      "reference/k/include/VPadShared.h",
+      "reference/k/src/drivers/func/VPadFunc.c"
+    ],
+    "notes": ""
+  },
+  "files": [
+    {"path": "interfaces/gc_func_ioctl.h", "sha256": "2c576ee03286c7fe3960fe41ba37fa35876a0273f4af30d5194965fbe40cd321"},
+    {"path": "mocks/gc_func_driver.c", "sha256": "25958f021e0e0795a5ad6aff346fed3af5d47ed901629aeae85c4d97da160692"},
+    {"path": "mocks/gc_func_driver_test.c", "sha256": "fc6cc5a40bd99f60b6fca19ceaa82089bf245c7dac18bdf26497f52112009e54"}
+  ],
+  "wiring": {
+    "how_to_hook": "Include gc_func_ioctl.h and link gc_func_driver.c in user-mode components to simulate driver IOCTL calls."
+  },
+  "results": {
+    "notes": "gcc test passed"
+  }
+}

--- a/GaymController/reports/GC-PAR-006.md
+++ b/GaymController/reports/GC-PAR-006.md
@@ -1,0 +1,23 @@
+# GC-PAR-006 — Func Driver IOCTL Stub
+
+## Summary
+Implemented interface definitions for GameCube functional driver IOCTLs and a mock driver stub with basic handlers for `IOCTL_GC_SET_REPORT` and `IOCTL_GC_SUBSCRIBE_RUMBLE`. Added a small harness test verifying request routing and state storage.
+
+## Interfaces/Contracts
+- `GC_REPORT` structure for controller state
+- `IOCTL_GC_SET_REPORT` / `IOCTL_GC_SUBSCRIBE_RUMBLE` codes
+
+## Files Changed
+- `interfaces/gc_func_ioctl.h`: defined IOCTL constants and `GC_REPORT`
+- `mocks/gc_func_driver.c`: stubbed `GcFuncDeviceControl` handler
+- `mocks/gc_func_driver_test.c`: minimal harness to exercise the stub
+
+## Wiring Instructions
+Include `gc_func_ioctl.h` and link `gc_func_driver.c` into user-mode components needing to simulate driver IOCTL calls.
+
+## Tests & Results
+- Compiled and ran `mocks/gc_func_driver_test.c` — outputs `ok`
+
+## Reference Used
+- `reference/k/include/VPadShared.h`
+- `reference/k/src/drivers/func/VPadFunc.c`

--- a/GaymController/reports/WIRING_GUIDE.md
+++ b/GaymController/reports/WIRING_GUIDE.md
@@ -1,0 +1,16 @@
+# WIRING GUIDE
+
+## GC-PAR-006 — Func Driver IOCTL Stub
+
+**Component:** parallel  
+**Reference consulted:** True  
+**Reference files:** reference/k/include/VPadShared.h, reference/k/src/drivers/func/VPadFunc.c  
+### Wiring Instructions
+
+Include gc_func_ioctl.h and link gc_func_driver.c in user-mode components to simulate driver IOCTL calls.
+
+### Files
+
+- `interfaces/gc_func_ioctl.h`  `2c576ee03286c7fe3960fe41ba37fa35876a0273f4af30d5194965fbe40cd321`
+- `mocks/gc_func_driver.c`  `25958f021e0e0795a5ad6aff346fed3af5d47ed901629aeae85c4d97da160692`
+- `mocks/gc_func_driver_test.c`  `fc6cc5a40bd99f60b6fca19ceaa82089bf245c7dac18bdf26497f52112009e54`

--- a/GaymController/tasks/parallel/GC-PAR-006.md
+++ b/GaymController/tasks/parallel/GC-PAR-006.md
@@ -4,7 +4,9 @@
 Work from **interfaces/** and **mocks/** only. Keep hot paths allocation-free. **Consult `reference/` first** to understand legacy behavior/feel.
 
 ## Paths to touch
-- (fill with your implementation files)
+- interfaces/gc_func_ioctl.h
+- mocks/gc_func_driver.c
+- mocks/gc_func_driver_test.c
 
 ## Reference guidelines
 - Look for any related files in `reference/originals/*`, `reference/aim/*`, or `reference/traces/*`.


### PR DESCRIPTION
## Summary
- define IOCTL constants and GC_REPORT layout for GameCube functional driver
- stub functional driver handler and basic rumble/report processing
- document wiring and add harness test

## Testing
- `gcc mocks/gc_func_driver_test.c -o /tmp/gc_test && /tmp/gc_test`
- `python tools/aggregate_reports.py`


------
https://chatgpt.com/codex/tasks/task_e_689bc8f86a4883209a8f86b0a352ca58