### PR TITLE
Add macro/turbo scheduler and tests

### DIFF
--- a/GaymController/reports/GC-PAR-018.json
+++ b/GaymController/reports/GC-PAR-018.json
@@ -1,0 +1,23 @@
+{
+  "task_id": "GC-PAR-018",
+  "title": "Macro/Turbo Scheduler",
+  "version": "0.1",
+  "component": "parallel",
+  "reference": {
+    "consulted": true,
+    "files": ["reference/PERFECT/Macros/MacroEngine.cs"],
+    "notes": ""
+  },
+  "files": [
+    { "path": "shared/Mapping/Scheduler.cs", "sha256": "7545fc0be1814b3f386e2a0198c647fcce66d1f809550bb39ddfe7ab83e345cc" },
+    { "path": "tests/Shared.Tests/Shared.Tests.csproj", "sha256": "77344ab66a4219236418f1a3deba65a17c18a1922121b3aa017ca6e535f91224" },
+    { "path": "tests/Shared.Tests/TurboSchedulerTests.cs", "sha256": "6fe664bbab43c614d088d5c3d93226339620412666b66d4fbb06ed1119738ac4" },
+    { "path": "reports/GC-PAR-018.md", "sha256": "7e9e02a8361a8f302964b058d359a9ccc7e5b922b9fb6a0357dc75728a966e88" }
+  ],
+  "wiring": {
+    "how_to_hook": "Create a Scheduler, register mapping nodes, and advance ticks from a timer loop."
+  },
+  "results": {
+    "notes": "dotnet test passing"
+  }
+}

--- a/GaymController/reports/GC-PAR-018.md
+++ b/GaymController/reports/GC-PAR-018.md
@@ -1,0 +1,20 @@
+# GC-PAR-018 — Macro/Turbo Scheduler
+
+## Summary
+Implemented a lightweight scheduler to drive macro/turbo nodes without allocations. Added unit test verifying TurboNode toggling based on tick timing.
+
+## Interfaces/Contracts
+- `shared/Mapping/INode.cs` – scheduler ticks `INode` instances via `OnTick`.
+
+## Files Changed
+- `shared/Mapping/Scheduler.cs`: new allocation-free scheduler.
+- `tests/Shared.Tests/TurboSchedulerTests.cs`: verifies scheduler with `TurboNode`.
+
+## Wiring Instructions
+Instantiate `Scheduler`, register mapping nodes, and call `Tick` with elapsed milliseconds from the main loop.
+
+## Tests & Results
+- `dotnet test tests/Shared.Tests/Shared.Tests.csproj`
+
+## Reference Used
+- `reference/PERFECT/Macros/MacroEngine.cs`

--- a/GaymController/shared/Mapping/Scheduler.cs
+++ b/GaymController/shared/Mapping/Scheduler.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Diagnostics;
+namespace GaymController.Shared.Mapping {
+    /// <summary>
+    /// Simple allocation-free scheduler that ticks registered nodes.
+    /// Intended for macro/turbo style updates where a steady tick is required.
+    /// </summary>
+    public sealed class Scheduler {
+        private readonly INode?[] _nodes;
+        private int _count;
+        /// <param name="capacity">Maximum number of nodes to track.</param>
+        public Scheduler(int capacity = 64){
+            _nodes = new INode?[capacity];
+            _count = 0;
+        }
+        /// <summary>Registers a node for ticking. Returns false if capacity exceeded.</summary>
+        public bool Add(INode node){
+            if(_count >= _nodes.Length) return false;
+            _nodes[_count++] = node;
+            return true;
+        }
+        /// <summary>
+        /// Ticks all nodes with the provided delta time in milliseconds.
+        /// </summary>
+        public void Tick(double dtMs){
+            var n = _count;
+            var arr = _nodes;
+            for(int i=0;i<n;i++) arr[i]!.OnTick(dtMs);
+        }
+    }
+}

--- a/GaymController/tests/Shared.Tests/Shared.Tests.csproj
+++ b/GaymController/tests/Shared.Tests/Shared.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../shared/Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+</Project>

--- a/GaymController/tests/Shared.Tests/TurboSchedulerTests.cs
+++ b/GaymController/tests/Shared.Tests/TurboSchedulerTests.cs
@@ -1,0 +1,23 @@
+using Xunit;
+using GaymController.Shared.Mapping;
+
+namespace GaymController.Shared.Tests {
+    public class TurboSchedulerTests {
+        [Fact]
+        public void TurboNode_Toggles_WithSchedulerTicks() {
+            var turbo = new TurboNode("t") { RateHz = 10.0, Duty = 0.5 };
+            turbo.OnEvent(new InputEvent("btn", 1.0, 0));
+            var sched = new Scheduler();
+            Assert.True(sched.Add(turbo));
+            // After 40ms -> still within duty (on)
+            sched.Tick(40.0);
+            Assert.True(turbo.Output());
+            // Advance another 20ms -> beyond duty -> off
+            sched.Tick(20.0);
+            Assert.False(turbo.Output());
+            // Advance 40ms -> new cycle, back on
+            sched.Tick(40.0);
+            Assert.True(turbo.Output());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add allocation-free Scheduler for ticking macro/turbo nodes
- cover TurboNode behaviour with unit test
- document work in GC-PAR-018 report

## Testing
- `dotnet test tests/Shared.Tests/Shared.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689bc9204938832087c92ecae47c0f45