### PR TITLE
Add log bundler and ETW event source

### DIFF
--- a/GaymController/.gitignore
+++ b/GaymController/.gitignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+*.zip

--- a/GaymController/shared/Diagnostics/GcEventSource.cs
+++ b/GaymController/shared/Diagnostics/GcEventSource.cs
@@ -1,0 +1,13 @@
+using System.Diagnostics.Tracing;
+
+namespace GaymController.Diagnostics {
+    /// <summary>Simple ETW provider for GaymController diagnostics.</summary>
+    [EventSource(Name="GaymController")]
+    public sealed class GcEventSource : EventSource {
+        public static readonly GcEventSource Log = new();
+        [Event(1, Level = EventLevel.Informational)]
+        public void Info(string message) => WriteEvent(1, message);
+        [Event(2, Level = EventLevel.Error)]
+        public void Error(string message) => WriteEvent(2, message);
+    }
+}

--- a/GaymController/shared/Diagnostics/ILogBundler.cs
+++ b/GaymController/shared/Diagnostics/ILogBundler.cs
@@ -1,0 +1,10 @@
+namespace GaymController.Diagnostics {
+    public interface ILogBundler {
+        /// <summary>Create a zip bundle containing log files and ETW traces.</summary>
+        /// <param name="outputPath">Path to the resulting .zip file.</param>
+        /// <param name="logDirectory">Directory containing plain log files.</param>
+        /// <param name="etwDirectory">Optional directory containing ETW trace files (.etl).</param>
+        /// <returns>Full path to the created bundle.</returns>
+        string CreateBundle(string outputPath, string logDirectory, string? etwDirectory = null);
+    }
+}

--- a/GaymController/shared/Diagnostics/LogBundler.cs
+++ b/GaymController/shared/Diagnostics/LogBundler.cs
@@ -1,0 +1,20 @@
+using System.IO;
+using System.IO.Compression;
+
+namespace GaymController.Diagnostics {
+    /// <summary>Bundles plain log files and ETW traces into a single archive.</summary>
+    public sealed class LogBundler : ILogBundler {
+        public string CreateBundle(string outputPath, string logDirectory, string? etwDirectory = null) {
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+            if (File.Exists(outputPath)) File.Delete(outputPath);
+            using var zip = ZipFile.Open(outputPath, ZipArchiveMode.Create);
+            if (Directory.Exists(logDirectory))
+                foreach (var file in Directory.GetFiles(logDirectory, "*", SearchOption.AllDirectories))
+                    zip.CreateEntryFromFile(file, Path.Combine("logs", Path.GetFileName(file)));
+            if (!string.IsNullOrEmpty(etwDirectory) && Directory.Exists(etwDirectory))
+                foreach (var file in Directory.GetFiles(etwDirectory, "*.etl", SearchOption.AllDirectories))
+                    zip.CreateEntryFromFile(file, Path.Combine("etw", Path.GetFileName(file)));
+            return outputPath;
+        }
+    }
+}

--- a/GaymController/tests/LogBundler.Tests/LogBundler.Tests.csproj
+++ b/GaymController/tests/LogBundler.Tests/LogBundler.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../shared/Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/GaymController/tests/LogBundler.Tests/LogBundlerTests.cs
+++ b/GaymController/tests/LogBundler.Tests/LogBundlerTests.cs
@@ -1,0 +1,20 @@
+using System.IO;
+using System.IO.Compression;
+using GaymController.Diagnostics;
+using Xunit;
+
+namespace Gc.Tests {
+    public class LogBundlerTests {
+        [Fact]
+        public void Bundler_Zips_LogFiles() {
+            var tempDir = Path.Combine(Path.GetTempPath(), "gc_logs");
+            Directory.CreateDirectory(tempDir);
+            File.WriteAllText(Path.Combine(tempDir, "a.log"), "hello");
+            var bundler = new LogBundler();
+            var zipPath = Path.Combine(Path.GetTempPath(), "bundle.zip");
+            bundler.CreateBundle(zipPath, tempDir);
+            using var zip = ZipFile.OpenRead(zipPath);
+            Assert.Contains(zip.Entries, e => e.FullName == "logs/a.log");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ILogBundler` interface and `LogBundler` implementation to zip log and ETW trace files
- introduce `GcEventSource` for emitting ETW diagnostics events
- cover log bundler with an xUnit test

## Testing
- `dotnet test tests/LogBundler.Tests/LogBundler.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689bc994cfe483208b2d2dbcd10b4fa2