### PR TITLE
GC-PAR-026: Add MSI/Signing pipeline task stubs

### DIFF
--- a/GaymController/tasks/parallel/GC-PAR-026.json
+++ b/GaymController/tasks/parallel/GC-PAR-026.json
@@ -1,6 +1,6 @@
 {
   "task_id": "GC-PAR-026",
-  "title": "Backpressure & Async Writes",
+  "title": "MSI/Signing pipeline stubs",
   "component": "parallel",
   "version": "0.1",
   "reference": {

--- a/GaymController/tasks/parallel/GC-PAR-026.md
+++ b/GaymController/tasks/parallel/GC-PAR-026.md
@@ -1,4 +1,4 @@
-# GC-PAR-026 — Backpressure & Async Writes
+# GC-PAR-026 — MSI/Signing pipeline stubs
 
 ## Context
 Work from **interfaces/** and **mocks/** only. Keep hot paths allocation-free. **Consult `reference/` first** to understand legacy behavior/feel.


### PR DESCRIPTION
## Summary
- Retitle GC-PAR-026 to focus on MSI/Signing pipeline work
- Update task metadata to reflect new MSI/Signing pipeline stub description

## Testing
- `python tools/aggregate_reports.py`

------
https://chatgpt.com/codex/tasks/task_e_689bc98f6154832091000f801b4d3eb0