### PR TITLE
Add legacy mouse aim plugin and performance harness

### DIFF
--- a/GaymController/.gitignore
+++ b/GaymController/.gitignore
@@ -1,0 +1,3 @@
+# Build outputs
+bin/
+obj/

--- a/GaymController/plugins/LegacyMouseAim.Legacy/CurveProcessor.cs
+++ b/GaymController/plugins/LegacyMouseAim.Legacy/CurveProcessor.cs
@@ -1,0 +1,107 @@
+using System;
+
+namespace LegacyMouseAim.Legacy
+{
+    public sealed class CurveProcessor
+    {
+        public float Sensitivity { get; set; } = 0.35f;   // global multiplier
+        public float Expo { get; set; } = 0.6f;           // 0 linear .. 1 cubic
+        public float AntiDeadzone { get; set; } = 0.05f;  // push off center
+        public float MaxSpeed { get; set; } = 1.0f;       // clamp in [-1..1]
+        public float EmaAlpha { get; set; } = 0.35f;      // smoothing 0..1
+        public float VelocityGain { get; set; } = 0.0f;   // extra scale by |v|
+        public float JitterFloor { get; set; } = 0.0f;    // ignore tiny deltas
+        public float ScaleX { get; set; } = 1.0f;
+        public float ScaleY { get; set; } = 1.0f;
+
+        private float _emaX, _emaY;
+        private float _lastR;
+
+        public (short X, short Y) ToStick(float dx, float dy)
+        {
+            // Convert mouse deltas to floating-point stick deltas using sensitivity and anisotropic scaling
+            float scale = Sensitivity / 50f;
+            float x = dx * scale * ScaleX;
+            float y = dy * scale * ScaleY;
+
+            // Compute radial magnitude
+            float r = MathF.Sqrt(x * x + y * y);
+            // Apply jitter floor radially rather than per-axis.  When the total movement is tiny, ignore it.
+            if (r < JitterFloor)
+            {
+                x = 0f;
+                y = 0f;
+                r = 0f;
+            }
+
+            if (r > 0f)
+            {
+                // Unit vector in direction of movement
+                float ux = x / r;
+                float uy = y / r;
+
+                // Velocity-based gain computed from change in radial magnitude instead of per-axis
+                float v = MathF.Abs(r - _lastR);
+                float velGain = 1f + VelocityGain * Math.Clamp(v, 0f, 1.5f);
+                r *= velGain;
+                _lastR = r;
+
+                // Normalize to 0..1 relative to maximum speed
+                float maxR = MaxSpeed > 0f ? MaxSpeed : 1f;
+                float rn = Math.Clamp(r / maxR, 0f, 1f);
+                // Apply exponential curve to radial magnitude
+                float expo = Expo;
+                if (expo > 0f)
+                {
+                    // Ease-out style: preserves fine aim and accelerates towards edges
+                    rn = MathF.Pow(rn, 1f - expo);
+                }
+
+                // Apply anti-deadzone radially
+                float adz = AntiDeadzone;
+                rn = rn <= 0f ? 0f : (adz + (1f - adz) * rn);
+
+                // Convert back to stick space (0..maxR)
+                float targetR = rn * maxR;
+                x = ux * targetR;
+                y = uy * targetR;
+            }
+            else
+            {
+                _lastR = 0f;
+            }
+
+            // Vector EMA smoothing: apply the same alpha to both axes based on the same radial magnitude
+            float alpha = EmaAlpha;
+            if (alpha > 0f)
+            {
+                _emaX += alpha * (x - _emaX);
+                _emaY += alpha * (y - _emaY);
+                x = _emaX;
+                y = _emaY;
+            }
+
+            // Final circular clamp.  Ensure the vector length does not exceed MaxSpeed.
+            float rr = MathF.Sqrt(x * x + y * y);
+            float m = MaxSpeed > 0f ? MaxSpeed : 1f;
+            if (rr > m)
+            {
+                float s = m / rr;
+                x *= s;
+                y *= s;
+            }
+
+            // Convert from [-1,1] to [-32768,32767] stick units.  Note Y is inverted for Xbox semantics.
+            short sx = (short)Math.Clamp(x * 32767f, -32768f, 32767f);
+            short sy = (short)Math.Clamp(-y * 32767f, -32768f, 32767f);
+            return (sx, sy);
+        }
+
+        public void ResetSmoothing()
+        {
+            _emaX = 0f;
+            _emaY = 0f;
+            _lastR = 0f;
+        }
+    }
+}

--- a/GaymController/plugins/LegacyMouseAim.Legacy/LegacyMouseAim.Legacy.csproj
+++ b/GaymController/plugins/LegacyMouseAim.Legacy/LegacyMouseAim.Legacy.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/GaymController/plugins/LegacyMouseAim.Legacy/LegacyMouseAim.cs
+++ b/GaymController/plugins/LegacyMouseAim.Legacy/LegacyMouseAim.cs
@@ -1,0 +1,28 @@
+namespace LegacyMouseAim.Legacy
+{
+    /// <summary>
+    /// Simple interface to translate mouse deltas into stick coordinates
+    /// using the legacy curve processor.
+    /// </summary>
+    public interface ILegacyMouseAim
+    {
+        (short X, short Y) Translate(int dx, int dy);
+        void Reset();
+    }
+
+    /// <summary>
+    /// Implementation of ILegacyMouseAim that mirrors the math from the
+    /// original project. Only the translation logic is preserved.
+    /// </summary>
+    public sealed class LegacyMouseAimTranslator : ILegacyMouseAim
+    {
+        private readonly CurveProcessor _curve = new();
+
+        public (short X, short Y) Translate(int dx, int dy)
+        {
+            return _curve.ToStick(dx, dy);
+        }
+
+        public void Reset() => _curve.ResetSmoothing();
+    }
+}

--- a/GaymController/tasks/compat/GC-LG-005.json
+++ b/GaymController/tasks/compat/GC-LG-005.json
@@ -4,15 +4,23 @@
   "version": "0.1",
   "component": "legacy",
   "reference": {
-    "consulted": false,
-    "files": [],
+    "consulted": true,
+    "files": [
+      "reference/PERFECT/Processing/CurveProcessor.cs"
+    ],
     "notes": ""
   },
-  "files": [],
+  "files": [
+    "plugins/LegacyMouseAim.Legacy/LegacyMouseAim.Legacy.csproj",
+    "plugins/LegacyMouseAim.Legacy/CurveProcessor.cs",
+    "plugins/LegacyMouseAim.Legacy/LegacyMouseAim.cs",
+    "tools/LegacyAimHarness/LegacyAimHarness.csproj",
+    "tools/LegacyAimHarness/Program.cs"
+  ],
   "wiring": {
-    "how_to_hook": ""
+    "how_to_hook": "dotnet run --project tools/LegacyAimHarness [iterations]"
   },
   "results": {
-    "notes": ""
+    "notes": "Harness ran 600000 iterations."
   }
 }

--- a/GaymController/tools/LegacyAimHarness/LegacyAimHarness.csproj
+++ b/GaymController/tools/LegacyAimHarness/LegacyAimHarness.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../plugins/LegacyMouseAim.Legacy/LegacyMouseAim.Legacy.csproj" />
+  </ItemGroup>
+</Project>

--- a/GaymController/tools/LegacyAimHarness/Program.cs
+++ b/GaymController/tools/LegacyAimHarness/Program.cs
@@ -1,0 +1,19 @@
+using System;
+using LegacyMouseAim.Legacy;
+
+int iterations = 600_000; // 10 minutes @1kHz
+if (args.Length > 0 && int.TryParse(args[0], out var iters))
+{
+    iterations = iters;
+}
+
+var translator = new LegacyMouseAimTranslator();
+var rand = new Random(0);
+for (int i = 0; i < iterations; i++)
+{
+    int dx = rand.Next(-5, 6);
+    int dy = rand.Next(-5, 6);
+    translator.Translate(dx, dy);
+}
+
+Console.WriteLine($"Processed {iterations} iterations using LegacyMouseAim");


### PR DESCRIPTION
## Summary
- port CurveProcessor math into LegacyMouseAim plugin implementing ILegacyMouseAim
- add LegacyAimHarness tool to stress test plugin with 600k iterations
- track work in GC-LG-005 task file and ignore build outputs

## Testing
- `dotnet build plugins/LegacyMouseAim.Legacy/LegacyMouseAim.Legacy.csproj`
- `dotnet build tools/LegacyAimHarness/LegacyAimHarness.csproj`
- `dotnet run --project tools/LegacyAimHarness/LegacyAimHarness.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689bc97f4e748320a70480f0ecf82559