### PR TITLE
feat: add optional Wooting SDK fallback

### DIFF
--- a/GaymController/src/GaymController.Wooting.Tests/GaymController.Wooting.Tests.csproj
+++ b/GaymController/src/GaymController.Wooting.Tests/GaymController.Wooting.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GaymController.Wooting\GaymController.Wooting.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+</Project>

--- a/GaymController/src/GaymController.Wooting.Tests/WootingProviderFactoryTests.cs
+++ b/GaymController/src/GaymController.Wooting.Tests/WootingProviderFactoryTests.cs
@@ -1,0 +1,12 @@
+using Xunit;
+using GaymController.Wooting;
+
+namespace GaymController.Wooting.Tests {
+    public class WootingProviderFactoryTests {
+        [Fact]
+        public void FallsBackToRawHidWhenSdkMissing(){
+            using var provider = WootingProviderFactory.Create();
+            Assert.IsType<RawHidProvider>(provider);
+        }
+    }
+}

--- a/GaymController/src/GaymController.Wooting/RawHidProvider.cs
+++ b/GaymController/src/GaymController.Wooting/RawHidProvider.cs
@@ -1,11 +1,62 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
 using GaymController.Shared.Mapping;
 
 namespace GaymController.Wooting {
-    // Stub - implement overlapped HID reads + mapping file application
+    /// <summary>
+    /// Basic raw HID provider that replays analog values based on a
+    /// per-device mapping file. The implementation is intentionally
+    /// lightweight and avoids per-frame allocations; it merely simulates
+    /// HID input to validate higher-level plumbing when real hardware or
+    /// SDK is unavailable.
+    /// </summary>
     public sealed class RawHidProvider : IWootingProvider {
+        private readonly Dictionary<int, string> _mapping = new();
+        private Thread? _worker;
+        private bool _running;
+
         public event EventHandler<InputEvent>? OnKeyAnalog;
-        public void Start(){ /* TODO */ } public void Stop(){ /* TODO */ }
+
+        public RawHidProvider(){
+            var mapPath = Path.Combine(AppContext.BaseDirectory, "wooting-mapping.json");
+            if (File.Exists(mapPath)){
+                try {
+                    var json = File.ReadAllText(mapPath);
+                    var dict = JsonSerializer.Deserialize<Dictionary<int,string>>(json);
+                    if (dict != null) foreach (var kv in dict) _mapping[kv.Key] = kv.Value;
+                } catch { /* ignore malformed mapping */ }
+            }
+        }
+
+        public void Start(){
+            if (_running) return;
+            _running = true;
+            _worker = new Thread(ReadLoop){ IsBackground = true };
+            _worker.Start();
+        }
+
+        private void ReadLoop(){
+            var rand = new Random();
+            while (_running){
+                Thread.Sleep(16); // ~60Hz
+                foreach (var kv in _mapping){
+                    var value = rand.NextDouble();
+                    OnKeyAnalog?.Invoke(this,
+                        new InputEvent(kv.Value, value,
+                            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()*1000));
+                }
+            }
+        }
+
+        public void Stop(){
+            _running = false;
+            _worker?.Join();
+            _worker = null;
+        }
+
         public void Dispose(){ Stop(); }
     }
 }

--- a/GaymController/src/GaymController.Wooting/SdkProvider.cs
+++ b/GaymController/src/GaymController.Wooting/SdkProvider.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Runtime.InteropServices;
+using GaymController.Shared.Mapping;
+
+namespace GaymController.Wooting {
+    /// <summary>
+    /// Provider that uses the optional Wooting analog SDK when the native
+    /// library is available on the system. The implementation only verifies
+    /// library presence; if the SDK cannot be loaded the caller should fall
+    /// back to <see cref="RawHidProvider"/>.
+    /// </summary>
+    public sealed class SdkProvider : IWootingProvider {
+        private IntPtr _handle;
+        public static bool IsAvailable {
+            get {
+                return NativeLibrary.TryLoad("wooting-analog-sdk", out _)
+                    || NativeLibrary.TryLoad("WootingAnalogWrapper", out _)
+                    || NativeLibrary.TryLoad("wooting_analog", out _);
+            }
+        }
+
+        public SdkProvider(){
+            if (!NativeLibrary.TryLoad("wooting-analog-sdk", out _handle)
+                && !NativeLibrary.TryLoad("WootingAnalogWrapper", out _handle)
+                && !NativeLibrary.TryLoad("wooting_analog", out _handle))
+                throw new DllNotFoundException("Wooting analog SDK not found");
+        }
+
+        public event EventHandler<InputEvent>? OnKeyAnalog;
+        public void Start(){ /* SDK polling would start here */ }
+        public void Stop(){ /* SDK polling would stop here */ }
+
+        public void Dispose(){
+            Stop();
+            if (_handle != IntPtr.Zero){
+                NativeLibrary.Free(_handle);
+                _handle = IntPtr.Zero;
+            }
+        }
+    }
+}

--- a/GaymController/src/GaymController.Wooting/WootingProviderFactory.cs
+++ b/GaymController/src/GaymController.Wooting/WootingProviderFactory.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace GaymController.Wooting {
+    /// <summary>
+    /// Factory that returns the best available <see cref="IWootingProvider"/>.
+    /// Prefers the optional SDK wrapper when present, otherwise falls back to
+    /// the raw HID implementation.
+    /// </summary>
+    public static class WootingProviderFactory {
+        public static IWootingProvider Create(){
+            return SdkProvider.IsAvailable
+                ? new SdkProvider()
+                : new RawHidProvider();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add factory that selects between Wooting SDK and raw HID provider
- stub SDK provider that loads native library if present
- simulate raw HID provider with mapping file and event loop
- add unit test covering SDK fallback path

## Testing
- `dotnet test src/GaymController.Wooting.Tests/GaymController.Wooting.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689bc96f27d483208db4fd58fc877024