### PR TITLE
Add opt-in anti-recoil node

### DIFF
--- a/GaymController/reports/GC-PAR-020.json
+++ b/GaymController/reports/GC-PAR-020.json
@@ -1,8 +1,8 @@
 {
   "task_id": "GC-PAR-020",
   "title": "Anti-Recoil Node",
-  "component": "parallel",
   "version": "0.1",
+  "component": "parallel",
   "reference": {
     "consulted": false,
     "files": [],
@@ -11,12 +11,10 @@
   "files": [
     {"path": "shared/Mapping/Nodes.cs", "sha256": "d10c603c45b3ded8da599b5009fa1c74f80ee5a39783fd729538ec4a44610967"},
     {"path": "tests/Mapping.Tests/AntiRecoilNodeTests.cs", "sha256": "4d8a47b24a9dd4b7c8e45b1be66951db1dc92e52fdba043862f4b7fc802c33b0"},
-    {"path": "tests/Mapping.Tests/Mapping.Tests.csproj", "sha256": "61a1ea1fa2abb2377e550c7c09f32c5fd4508c561ca0f276ef4461845d257ac3"},
-    {"path": "reports/GC-PAR-020.md", "sha256": "5a6a472f9bc66499ebb4db3000e2221a53585662bf5c7de9c03bf2141ffdc0a7"},
-    {"path": "reports/GC-PAR-020.json", "sha256": "8c471a54bc81f7f40f515002ae80f83d3d8db51a701df70d4032bb497c78317b"}
+    {"path": "tests/Mapping.Tests/Mapping.Tests.csproj", "sha256": "61a1ea1fa2abb2377e550c7c09f32c5fd4508c561ca0f276ef4461845d257ac3"}
   ],
   "wiring": {
-    "how_to_hook": "Add AntiRecoilNode to the mapping graph and set Enabled true when users opt in."
+    "how_to_hook": "Instantiate AntiRecoilNode and enable it when the user opts in; feed Fire events to trigger compensation."
   },
   "results": {
     "notes": "dotnet test passed for anti-recoil node."

--- a/GaymController/reports/GC-PAR-020.md
+++ b/GaymController/reports/GC-PAR-020.md
@@ -1,0 +1,22 @@
+# GC-PAR-020 — Anti-Recoil Node
+
+## Summary
+Implemented an opt-in anti-recoil mapping node with exponential decay and unit tests validating activation and decay behaviour.
+
+## Interfaces/Contracts
+- `AntiRecoilNode` implementing `INode`
+- `InputEvent` from `Shared.Mapping`
+
+## Files Changed
+- `shared/Mapping/Nodes.cs`: added opt-in flag and state management.
+- `tests/Mapping.Tests/Mapping.Tests.csproj`: xUnit test project.
+- `tests/Mapping.Tests/AntiRecoilNodeTests.cs`: unit tests for anti-recoil logic.
+
+## Wiring Instructions
+Instantiate `AntiRecoilNode` in the mapping graph. Set `Enabled` to `true` when the user opts in and feed `Fire` events to drive compensation.
+
+## Tests & Results
+- `dotnet test` – all tests pass.
+
+## Reference Used
+None found in `reference/`.

--- a/GaymController/shared/Mapping/Nodes.cs
+++ b/GaymController/shared/Mapping/Nodes.cs
@@ -31,13 +31,19 @@ namespace GaymController.Shared.Mapping {
     }
     public sealed class AntiRecoilNode : INode {
         public string Id{get;} public double VerticalComp{get;set;}=0.15; public double DecayMs{get;set;}=120.0;
+        public bool Enabled{get;set;}=false;
         private double _v; private bool _armed;
         public AntiRecoilNode(string id){ Id=id; }
         public void OnEvent(InputEvent e){
-            if(e.Source=="Fire" && e.Value>0.5){ _armed=true; _v=VerticalComp; }
-            if(e.Source=="Fire" && e.Value<=0.5){ _armed=false; }
+            if(e.Source!="Fire") return;
+            if(Enabled && e.Value>0.5){ _armed=true; _v=VerticalComp; }
+            else { _armed=false; _v=0.0; }
         }
-        public void OnTick(double dtMs){ if(!_armed)return; var k = Math.Exp(-dtMs/Math.Max(1.0,DecayMs)); _v*=k; }
-        public double Output()=> -_v;
+        public void OnTick(double dtMs){
+            if(!Enabled || !_armed) return;
+            var k = Math.Exp(-dtMs/Math.Max(1.0,DecayMs));
+            _v*=k;
+        }
+        public double Output()=> (Enabled && _armed) ? -_v : 0.0;
     }
 }

--- a/GaymController/tasks/parallel/GC-PAR-020.md
+++ b/GaymController/tasks/parallel/GC-PAR-020.md
@@ -4,7 +4,13 @@
 Work from **interfaces/** and **mocks/** only. Keep hot paths allocation-free. **Consult `reference/` first** to understand legacy behavior/feel.
 
 ## Paths to touch
-- (fill with your implementation files)
+- shared/Mapping/Nodes.cs
+- tests/Mapping.Tests/AntiRecoilNodeTests.cs
+- tests/Mapping.Tests/Mapping.Tests.csproj
+- tasks/parallel/GC-PAR-020.md
+- tasks/parallel/GC-PAR-020.json
+- reports/GC-PAR-020.md
+- reports/GC-PAR-020.json
 
 ## Reference guidelines
 - Look for any related files in `reference/originals/*`, `reference/aim/*`, or `reference/traces/*`.

--- a/GaymController/tests/Mapping.Tests/AntiRecoilNodeTests.cs
+++ b/GaymController/tests/Mapping.Tests/AntiRecoilNodeTests.cs
@@ -1,0 +1,28 @@
+using System;
+using GaymController.Shared.Mapping;
+using Xunit;
+
+namespace Mapping.Tests {
+    public class AntiRecoilNodeTests {
+        [Fact]
+        public void DisabledNodeProducesNoOutput() {
+            var node = new AntiRecoilNode("ar") { VerticalComp = 0.2 };
+            node.OnEvent(new InputEvent("Fire", 1.0, 0));
+            node.OnTick(16.0);
+            Assert.Equal(0.0, node.Output());
+        }
+
+        [Fact]
+        public void EnabledNodeDecaysOverTime() {
+            var node = new AntiRecoilNode("ar") { Enabled = true, VerticalComp = 0.2, DecayMs = 100.0 };
+            node.OnEvent(new InputEvent("Fire", 1.0, 0));
+            Assert.Equal(-0.2, node.Output(), 5);
+            node.OnTick(50.0);
+            var expected = -0.2 * Math.Exp(-50.0 / 100.0);
+            Assert.InRange(node.Output(), expected - 1e-6, expected + 1e-6);
+            node.OnEvent(new InputEvent("Fire", 0.0, 0));
+            node.OnTick(10.0);
+            Assert.Equal(0.0, node.Output(), 5);
+        }
+    }
+}

--- a/GaymController/tests/Mapping.Tests/Mapping.Tests.csproj
+++ b/GaymController/tests/Mapping.Tests/Mapping.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../shared/Shared.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add opt-in flag and decay handling for anti-recoil mapping node
- cover anti-recoil behavior with xUnit tests
- document wiring and task metadata for GC-PAR-020

## Testing
- `dotnet test tests/Mapping.Tests/Mapping.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689bc9493f58832080e3909795ceb823