### PR TITLE
Add legacy mouse aim plugin and parity harness

### DIFF
--- a/GaymController/plugins/LegacyMouseAim.Legacy/ILegacyMouseAim.cs
+++ b/GaymController/plugins/LegacyMouseAim.Legacy/ILegacyMouseAim.cs
@@ -1,0 +1,26 @@
+namespace LegacyMouseAim.Legacy;
+
+/// <summary>
+/// Contract for the legacy mouse aim translator used by the compatibility
+/// harness.  The interface mirrors the options exposed by the original
+/// implementation so that the math can be exercised without pulling in the
+/// entire legacy project.
+/// </summary>
+public interface ILegacyMouseAim
+{
+    float Sensitivity { get; set; }
+    float Expo { get; set; }
+    float AntiDeadzone { get; set; }
+    float MaxSpeed { get; set; }
+    float EmaAlpha { get; set; }
+    float VelocityGain { get; set; }
+    float JitterFloor { get; set; }
+    float ScaleX { get; set; }
+    float ScaleY { get; set; }
+
+    /// <summary>Translate raw mouse delta values into stick units.</summary>
+    (short X, short Y) ToStick(float dx, float dy);
+
+    /// <summary>Reset internal smoothing state.</summary>
+    void ResetSmoothing();
+}

--- a/GaymController/plugins/LegacyMouseAim.Legacy/LegacyMouseAim.Legacy.csproj
+++ b/GaymController/plugins/LegacyMouseAim.Legacy/LegacyMouseAim.Legacy.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/GaymController/plugins/LegacyMouseAim.Legacy/LegacyMouseAim.cs
+++ b/GaymController/plugins/LegacyMouseAim.Legacy/LegacyMouseAim.cs
@@ -1,0 +1,111 @@
+using System;
+
+namespace LegacyMouseAim.Legacy;
+
+/// <summary>
+/// Port of the original <c>CurveProcessor</c> from the reference project.
+/// The behavior is kept byte-for-byte to preserve the exact feel of the
+/// legacy mouse aim implementation.
+/// </summary>
+public sealed class LegacyMouseAim : ILegacyMouseAim
+{
+    public float Sensitivity { get; set; } = 0.35f;   // global multiplier
+    public float Expo { get; set; } = 0.6f;           // 0 linear .. 1 cubic
+    public float AntiDeadzone { get; set; } = 0.05f;  // push off center
+    public float MaxSpeed { get; set; } = 1.0f;       // clamp in [-1..1]
+    public float EmaAlpha { get; set; } = 0.35f;      // smoothing 0..1
+    public float VelocityGain { get; set; } = 0.0f;   // extra scale by |v|
+    public float JitterFloor { get; set; } = 0.0f;    // ignore tiny deltas
+    public float ScaleX { get; set; } = 1.0f;
+    public float ScaleY { get; set; } = 1.0f;
+
+    private float _emaX, _emaY;
+    private float _lastR;
+
+    public (short X, short Y) ToStick(float dx, float dy)
+    {
+        // Convert mouse deltas to floating-point stick deltas using sensitivity and anisotropic scaling
+        float scale = Sensitivity / 50f;
+        float x = dx * scale * ScaleX;
+        float y = dy * scale * ScaleY;
+
+        // Compute radial magnitude
+        float r = MathF.Sqrt(x * x + y * y);
+        // Apply jitter floor radially rather than per-axis.  When the total movement is tiny, ignore it.
+        if (r < JitterFloor)
+        {
+            x = 0f;
+            y = 0f;
+            r = 0f;
+        }
+
+        if (r > 0f)
+        {
+            // Unit vector in direction of movement
+            float ux = x / r;
+            float uy = y / r;
+
+            // Velocity-based gain computed from change in radial magnitude instead of per-axis
+            float v = MathF.Abs(r - _lastR);
+            float velGain = 1f + VelocityGain * Math.Clamp(v, 0f, 1.5f);
+            r *= velGain;
+            _lastR = r;
+
+            // Normalize to 0..1 relative to maximum speed
+            float maxR = MaxSpeed > 0f ? MaxSpeed : 1f;
+            float rn = Math.Clamp(r / maxR, 0f, 1f);
+            // Apply exponential curve to radial magnitude
+            float expo = Expo;
+            if (expo > 0f)
+            {
+                // Ease-out style: preserves fine aim and accelerates towards edges
+                rn = MathF.Pow(rn, 1f - expo);
+            }
+
+            // Apply anti-deadzone radially
+            float adz = AntiDeadzone;
+            rn = rn <= 0f ? 0f : (adz + (1f - adz) * rn);
+
+            // Convert back to stick space (0..maxR)
+            float targetR = rn * maxR;
+            x = ux * targetR;
+            y = uy * targetR;
+        }
+        else
+        {
+            _lastR = 0f;
+        }
+
+        // Vector EMA smoothing: apply the same alpha to both axes based on the same radial magnitude
+        float alpha = EmaAlpha;
+        if (alpha > 0f)
+        {
+            _emaX += alpha * (x - _emaX);
+            _emaY += alpha * (y - _emaY);
+            x = _emaX;
+            y = _emaY;
+        }
+
+        // Final circular clamp.  Ensure the vector length does not exceed MaxSpeed.
+        float rr = MathF.Sqrt(x * x + y * y);
+        float m = MaxSpeed > 0f ? MaxSpeed : 1f;
+        if (rr > m)
+        {
+            float s = m / rr;
+            x *= s;
+            y *= s;
+        }
+
+        // Convert from [-1,1] to [-32768,32767] stick units.  Note Y is inverted for Xbox semantics.
+        short sx = (short)Math.Clamp(x * 32767f, -32768f, 32767f);
+        short sy = (short)Math.Clamp(-y * 32767f, -32768f, 32767f);
+        return (sx, sy);
+    }
+
+    public void ResetSmoothing()
+    {
+        _emaX = 0f;
+        _emaY = 0f;
+        _lastR = 0f;
+    }
+}

--- a/GaymController/tools/LegacyAimHarness/LegacyAimHarness.csproj
+++ b/GaymController/tools/LegacyAimHarness/LegacyAimHarness.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\plugins\LegacyMouseAim.Legacy\LegacyMouseAim.Legacy.csproj" />
+  </ItemGroup>
+</Project>

--- a/GaymController/tools/LegacyAimHarness/Program.cs
+++ b/GaymController/tools/LegacyAimHarness/Program.cs
@@ -1,0 +1,101 @@
+using System;
+using LegacyAim = LegacyMouseAim.Legacy.LegacyMouseAim;
+
+// Simple harness that compares the ported implementation against a direct copy
+// of the original reference algorithm.  The comparison is used both as a unit
+// test and as a curve preview generator.
+
+// Reference implementation copied verbatim from reference/Processing/CurveProcessor.cs
+// but kept internal to the harness to serve as the golden version.
+class ReferenceCurveProcessor
+{
+    public float Sensitivity { get; set; } = 0.35f;
+    public float Expo { get; set; } = 0.6f;
+    public float AntiDeadzone { get; set; } = 0.05f;
+    public float MaxSpeed { get; set; } = 1.0f;
+    public float EmaAlpha { get; set; } = 0.35f;
+    public float VelocityGain { get; set; } = 0.0f;
+    public float JitterFloor { get; set; } = 0.0f;
+    public float ScaleX { get; set; } = 1.0f;
+    public float ScaleY { get; set; } = 1.0f;
+
+    private float _emaX, _emaY;
+    private float _lastR;
+
+    public (short X, short Y) ToStick(float dx, float dy)
+    {
+        float scale = Sensitivity / 50f;
+        float x = dx * scale * ScaleX;
+        float y = dy * scale * ScaleY;
+        float r = MathF.Sqrt(x * x + y * y);
+        if (r < JitterFloor)
+        {
+            x = 0f; y = 0f; r = 0f;
+        }
+        if (r > 0f)
+        {
+            float ux = x / r;
+            float uy = y / r;
+            float v = MathF.Abs(r - _lastR);
+            float velGain = 1f + VelocityGain * Math.Clamp(v, 0f, 1.5f);
+            r *= velGain;
+            _lastR = r;
+            float maxR = MaxSpeed > 0f ? MaxSpeed : 1f;
+            float rn = Math.Clamp(r / maxR, 0f, 1f);
+            float expo = Expo;
+            if (expo > 0f)
+            {
+                rn = MathF.Pow(rn, 1f - expo);
+            }
+            float adz = AntiDeadzone;
+            rn = rn <= 0f ? 0f : (adz + (1f - adz) * rn);
+            float targetR = rn * maxR;
+            x = ux * targetR;
+            y = uy * targetR;
+        }
+        else
+        {
+            _lastR = 0f;
+        }
+        float alpha = EmaAlpha;
+        if (alpha > 0f)
+        {
+            _emaX += alpha * (x - _emaX);
+            _emaY += alpha * (y - _emaY);
+            x = _emaX;
+            y = _emaY;
+        }
+        float rr = MathF.Sqrt(x * x + y * y);
+        float m = MaxSpeed > 0f ? MaxSpeed : 1f;
+        if (rr > m)
+        {
+            float s = m / rr;
+            x *= s; y *= s;
+        }
+        short sx = (short)Math.Clamp(x * 32767f, -32768f, 32767f);
+        short sy = (short)Math.Clamp(-y * 32767f, -32768f, 32767f);
+        return (sx, sy);
+    }
+}
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        var legacy = new LegacyAim();
+        var reference = new ReferenceCurveProcessor();
+
+        double maxErr = 0;
+        for (int dx = 0; dx <= 100; dx += 5)
+        {
+            var a = legacy.ToStick(dx, 0);
+            var b = reference.ToStick(dx, 0);
+            double errX = Math.Abs(a.X - b.X) / 32767.0;
+            double errY = Math.Abs(a.Y - b.Y) / 32767.0;
+            maxErr = Math.Max(maxErr, Math.Max(errX, errY));
+            Console.WriteLine($"dx={dx,3} -> plugin: ({a.X,6},{a.Y,6}) reference: ({b.X,6},{b.Y,6}) errX={errX:P3} errY={errY:P3}");
+        }
+        Console.WriteLine($"Max error: {maxErr:P3}");
+        return maxErr <= 0.01 ? 0 : 1; // ≤1%
+    }
+}


### PR DESCRIPTION
## Summary
- implement ILegacyMouseAim interface with original curve options
- port legacy CurveProcessor math into LegacyMouseAim plugin
- add LegacyAimHarness tool that compares plugin output to a reference copy

## Testing
- `dotnet build plugins/LegacyMouseAim.Legacy/LegacyMouseAim.Legacy.csproj`
- `dotnet run --project tools/LegacyAimHarness/LegacyAimHarness.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689bc978d1d483208f60aea41444d81a