### PR TITLE
Implement Wooting raw HID provider

### DIFF
--- a/GaymController/reports/GC-W-004.json
+++ b/GaymController/reports/GC-W-004.json
@@ -1,0 +1,15 @@
+{
+  "task_id": "GC-W-004",
+  "title": "Mapping Graph Hookup (KeyAnalogEvent)",
+  "version": "1.0",
+  "component": "GaymController.Wooting",
+  "reference": {"consulted": false, "files": [], "notes": ""},
+  "files": [
+    {"path": "src/GaymController.Wooting/RawHidProvider.cs", "sha256": "581cde33447db2531ace338bc4ecdee2372cd8d036e55deeb961e438b4a4be69"},
+    {"path": "src/GaymController.Wooting/GaymController.Wooting.csproj", "sha256": "cad456325967ef80f64b6f26b10f1265250472ddc73a15d2b5ede9d29ff39217"},
+    {"path": "src/GaymController.Wooting.Tests/GaymController.Wooting.Tests.csproj", "sha256": "59d9669474eace979e242bc76b9e133c4a4db927318573fbf44bfe2f48ec0f81"},
+    {"path": "src/GaymController.Wooting.Tests/RawHidProviderTests.cs", "sha256": "b51d9ac332dba3d749f3dc276f2d7a208acd66f9c64efc2eff7664246eacc444"}
+  ],
+  "wiring": {"how_to_hook": "Call RawHidProvider.FromJson with per-device mapping and subscribe to OnKeyAnalog."},
+  "results": {"perf_ms": 0, "notes": "dotnet test passed"}
+}

--- a/GaymController/reports/GC-W-004.md
+++ b/GaymController/reports/GC-W-004.md
@@ -1,0 +1,23 @@
+# GC-W-004 — Mapping Graph Hookup (KeyAnalogEvent)
+
+## Summary
+Implemented RawHidProvider to read Wooting analog reports via raw HID and emit mapping graph InputEvents.
+
+## Interfaces/Contracts
+- `RawHidProvider` raises `OnKeyAnalog` with `InputEvent` containing source name, normalized value, and timestamp.
+- `RawHidProvider.FromJson(path)` loads vendor/product IDs, report size, and byte-to-key mapping.
+
+## Files Changed
+- `src/GaymController.Wooting/RawHidProvider.cs`: implemented HID read loop and mapping application.
+- `src/GaymController.Wooting/GaymController.Wooting.csproj`: added HidSharp dependency.
+- `src/GaymController.Wooting.Tests/GaymController.Wooting.Tests.csproj`: test project targeting net8.0-windows.
+- `src/GaymController.Wooting.Tests/RawHidProviderTests.cs`: unit test covering byte-to-event mapping.
+
+## Wiring Instructions
+Instantiate using `RawHidProvider.FromJson(<mapping.json>)` and subscribe to `OnKeyAnalog` to forward events into the mapping graph.
+
+## Tests & Results
+- `dotnet test src/GaymController.Wooting.Tests/GaymController.Wooting.Tests.csproj` – passed.
+
+## Reference Used
+None

--- a/GaymController/src/GaymController.Wooting.Tests/GaymController.Wooting.Tests.csproj
+++ b/GaymController/src/GaymController.Wooting.Tests/GaymController.Wooting.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GaymController.Wooting\GaymController.Wooting.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/GaymController/src/GaymController.Wooting.Tests/GlobalUsings.cs
+++ b/GaymController/src/GaymController.Wooting.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/GaymController/src/GaymController.Wooting.Tests/RawHidProviderTests.cs
+++ b/GaymController/src/GaymController.Wooting.Tests/RawHidProviderTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using GaymController.Shared.Mapping;
+using Xunit;
+
+namespace GaymController.Wooting.Tests {
+    public class RawHidProviderTests {
+        [Fact]
+        public void MapsBytesToEvents(){
+            var reports = new byte[]{0,10,20,0,30,40}; // two reports of 3 bytes
+            var opened=false;
+            Stream Open(){
+                if(opened) throw new IOException("reopen");
+                opened=true;
+                return new MemoryStream(reports);
+            }
+            var map = new Dictionary<int,string>{{1,"A"},{2,"B"}};
+            var provider = new RawHidProvider(0x1234,0x5678,3,map,Open);
+            var events = new List<InputEvent>();
+            provider.OnKeyAnalog += (_,e)=>events.Add(e);
+            provider.Start();
+            SpinWait.SpinUntil(()=>events.Count>=4,1000);
+            provider.Stop();
+            Assert.Equal(4, events.Count);
+            Assert.Equal("A", events[0].Source);
+            Assert.Equal(10/255.0, events[0].Value,3);
+            Assert.Equal("B", events[1].Source);
+            Assert.Equal(20/255.0, events[1].Value,3);
+        }
+    }
+}

--- a/GaymController/src/GaymController.Wooting/GaymController.Wooting.csproj
+++ b/GaymController/src/GaymController.Wooting/GaymController.Wooting.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\shared\Shared.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="HidSharp" Version="2.1.0" />
+  </ItemGroup>
 </Project>

--- a/GaymController/src/GaymController.Wooting/RawHidProvider.cs
+++ b/GaymController/src/GaymController.Wooting/RawHidProvider.cs
@@ -1,11 +1,89 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using GaymController.Shared.Mapping;
+using HidSharp;
 
 namespace GaymController.Wooting {
-    // Stub - implement overlapped HID reads + mapping file application
+    // Raw HID provider that maps incoming bytes to keys using a JSON mapping file.
     public sealed class RawHidProvider : IWootingProvider {
+        private readonly int _vendorId;
+        private readonly int _productId;
+        private readonly int _reportSize;
+        private readonly Dictionary<int,string> _map;
+        private readonly Func<Stream>? _openOverride;
+        private CancellationTokenSource? _cts;
+        private Task? _task;
+
         public event EventHandler<InputEvent>? OnKeyAnalog;
-        public void Start(){ /* TODO */ } public void Stop(){ /* TODO */ }
+
+        public RawHidProvider(int vendorId, int productId, int reportSize,
+                              Dictionary<int,string> map, Func<Stream>? openOverride = null){
+            _vendorId = vendorId; _productId = productId; _reportSize = reportSize;
+            _map = map; _openOverride = openOverride;
+        }
+
+        public static RawHidProvider FromJson(string path, Func<Stream>? openOverride = null){
+            using var doc = JsonDocument.Parse(File.ReadAllText(path));
+            var root = doc.RootElement;
+            int vid = root.GetProperty("vendorId").GetInt32();
+            int pid = root.GetProperty("productId").GetInt32();
+            int size = root.GetProperty("reportSize").GetInt32();
+            var map = new Dictionary<int,string>();
+            foreach(var p in root.GetProperty("mapping").EnumerateObject())
+                map[int.Parse(p.Name)] = p.Value.GetString() ?? string.Empty;
+            return new RawHidProvider(vid,pid,size,map,openOverride);
+        }
+
+        private Stream OpenDevice(){
+            if(_openOverride != null) return _openOverride();
+            var dev = DeviceList.Local.GetHidDevices(_vendorId, _productId).FirstOrDefault();
+            if(dev == null) throw new InvalidOperationException("Device not found");
+            return dev.Open();
+        }
+
+        public void Start(){
+            if(_cts != null) return;
+            _cts = new CancellationTokenSource();
+            _task = Task.Run(() => ReadLoop(_cts.Token));
+        }
+
+        private void ReadLoop(CancellationToken token){
+            while(!token.IsCancellationRequested){
+                Stream? s = null;
+                try{
+                    s = OpenDevice();
+                    var buf = new byte[_reportSize];
+                    while(!token.IsCancellationRequested){
+                        int read = s.Read(buf,0,buf.Length);
+                        if(read<=0) break;
+                        long ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()*1000;
+                        foreach(var kv in _map){
+                            if(kv.Key < read){
+                                double val = buf[kv.Key]/255.0;
+                                OnKeyAnalog?.Invoke(this,new InputEvent(kv.Value,val,ts));
+                            }
+                        }
+                    }
+                } catch {
+                    Thread.Sleep(1000);
+                } finally {
+                    s?.Dispose();
+                }
+            }
+        }
+
+        public void Stop(){
+            if(_cts == null) return;
+            _cts.Cancel();
+            try{ _task?.Wait(); } catch{}
+            _cts.Dispose(); _cts=null; _task=null;
+        }
+
         public void Dispose(){ Stop(); }
     }
 }


### PR DESCRIPTION
## Summary
- implement RawHidProvider that opens Wooting keyboards over raw HID and maps bytes to key analog events
- add HidSharp dependency and unit test for byte-to-event mapping
- document work and tests in GC-W-004 reports

## Testing
- `dotnet test src/GaymController.Wooting.Tests/GaymController.Wooting.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689bc969b82c832086e539a64b8dee7d